### PR TITLE
Initial check-in with syntax coloring.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,3 @@
+.vscode/**
+.vscode-test/**
+.gitignore

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,9 @@
+# This the official list of Bazel authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as:
+# Name or Organization <email address>
+# The email address is not required for organizations.
+
+Google Inc.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,12 @@
+# People who have agreed to one of the CLAs and can contribute patches.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# https://developers.google.com/open-source/cla/individual
+# https://developers.google.com/open-source/cla/corporate
+#
+# Names should be added to this file as:
+#     Name <email address>
+
+Tony Allevato <allevato@google.com>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "vscode-bazel",
+    "displayName": "vscode-bazel",
+    "description": "Bazel BUILD integration",
+    "version": "0.0.1",
+    "publisher": "BazelBuild",
+    "engines": {
+        "vscode": "^1.27.0"
+    },
+    "categories": [
+        "Programming Languages"
+    ],
+    "contributes": {
+        "languages": [{
+            "id": "starlark",
+            "aliases": ["Starlark", "starlark", "Bazel"],
+            "extensions": [".bzl", ".BUILD"],
+            "filenames": ["BUILD", "BUILD.bazel", "WORKSPACE"],
+            "configuration": "./syntaxes/starlark.configuration.json"
+        }],
+        "grammars": [{
+            "language": "starlark",
+            "scopeName": "source.starlark",
+            "path": "./syntaxes/starlark.tmLanguage.json"
+        }]
+    }
+}

--- a/syntaxes/starlark.configuration.json
+++ b/syntaxes/starlark.configuration.json
@@ -1,0 +1,32 @@
+{
+    "comments": {
+        "lineComment": "#"
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        {
+            "open": "\"",
+            "close": "\"",
+            "notIn": ["string", "comment"]
+        },
+        {
+            "open": "'",
+            "close": "'",
+            "notIn": ["string", "comment"]
+        }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -1,0 +1,929 @@
+{
+    "name": "Starlark",
+    "scopeName": "source.starlark",
+    "fileTypes": [
+        "bzl"
+    ],
+    "patterns": [
+        {
+            "include": "#statement"
+        },
+        {
+            "include": "#expression"
+        }
+    ],
+    "repository": {
+        "statement": {
+            "patterns": [
+                {
+                    "include": "#function-definition"
+                },
+                {
+                    "include": "#statement-keyword"
+                },
+                {
+                    "include": "#assignment-operator"
+                },
+                {
+                    "include": "#docstring-statement"
+                },
+                {
+                    "include": "#discouraged-semicolon"
+                }
+            ]
+        },
+        "docstring-statement": {
+            "begin": "^(?=\\s*r?('''|\"\"\"|'|\"))",
+            "end": "(?<='''|\"\"\"|'|\")",
+            "patterns": [
+                {
+                    "include": "#docstring"
+                }
+            ]
+        },
+        "docstring": {
+            "patterns": [
+                {
+                    "name": "comment.block.documentation.starlark",
+                    "begin": "('''|\"\"\")",
+                    "end": "(\\1)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.begin.starlark"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.starlark"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#code-tag"
+                        },
+                        {
+                            "include": "#docstring-content"
+                        }
+                    ]
+                },
+                {
+                    "name": "comment.block.documentation.starlark",
+                    "begin": "(r)('''|\"\"\")",
+                    "end": "(\\2)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "storage.type.string.starlark"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.string.begin.starlark"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.starlark"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#string-consume-escape"
+                        },
+                        {
+                            "include": "#code-tag"
+                        }
+                    ]
+                },
+                {
+                    "name": "comment.line.documentation.starlark",
+                    "begin": "('|\")",
+                    "end": "(\\1)|((?<!\\\\)\\n)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.begin.starlark"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.starlark"
+                        },
+                        "2": {
+                            "name": "invalid.illegal.newline.starlark"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#code-tag"
+                        },
+                        {
+                            "include": "#docstring-content"
+                        }
+                    ]
+                },
+                {
+                    "name": "comment.line.documentation.starlark",
+                    "begin": "(r)('|\")",
+                    "end": "(\\2)|((?<!\\\\)\\n)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "storage.type.string.starlark"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.string.begin.starlark"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.starlark"
+                        },
+                        "2": {
+                            "name": "invalid.illegal.newline.starlark"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#string-consume-escape"
+                        },
+                        {
+                            "include": "#code-tag"
+                        }
+                    ]
+                }
+            ]
+        },
+        "docstring-content": {
+            "patterns": [
+                {
+                    "include": "#string-escape-sequence"
+                },
+                {
+                    "include": "#discouraged-string-line-continuation"
+                }
+            ]
+        },
+        "statement-keyword": {
+            "patterns": [
+                {
+                    "name": "storage.type.function.starlark",
+                    "match": "\\b(\\s*def)\\b"
+                },
+                {
+                    "name": "keyword.control.flow.starlark",
+                    "match": "\\b(?<!\\.)(break|continue|elif|else|for|if|pass|return)\\b"
+                },
+                {
+                    "name": "invalid.illegal.keyword.starlark",
+                    "match": "\\b(?<!\\.)(as|assert|class|del|except|finally|from|global|import|is|lambda|nonlocal|raise|try|while|with|yield)\\b"
+                }
+            ]
+        },
+        "expression-base": {
+            "patterns": [
+                {
+                    "include": "#line-comment"
+                },
+                {
+                    "include": "#literal"
+                },
+                {
+                    "include": "#string"
+                },
+                {
+                    "include": "#illegal-operator"
+                },
+                {
+                    "include": "#operator"
+                },
+                {
+                    "include": "#dictionary-literal"
+                },
+                {
+                    "include": "#subscript-expression"
+                },
+                {
+                    "include": "#list-literal"
+                },
+                {
+                    "include": "#parenthesized-expression"
+                },
+                {
+                    "include": "#function-call"
+                },
+                {
+                    "include": "#builtin-function"
+                },
+                {
+                    "include": "#constant-identifier"
+                },
+                {
+                    "include": "#type-identifier"
+                },
+                {
+                    "include": "#illegal-name"
+                },
+                {
+                    "include": "#line-continuation"
+                }
+            ]
+        },
+        "expression": {
+            "patterns": [
+                {
+                    "include": "#expression-base"
+                },
+                {
+                    "include": "#member-access"
+                },
+                {
+                    "include": "#variable"
+                }
+            ]
+        },
+        "variable": {
+            "match": "\\b([[:alpha:]_]\\w*)\\b",
+            "name": "variable.other.starlark"
+        },
+        "member-access": {
+            "begin": "(\\.)\\s*(?!\\.)",
+            "end": "(?# Stop when we read non-whitespace followed by non-word; i.e. when finished reading an identifier or function call)(?<=\\S)(?=\\W)|(?# Stop when seeing the start of something that's not a word; e.g., a non-identifier)(^|(?<=\\s))(?=[^\\\\\\w\\s])|$",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.accessor.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#function-call"
+                },
+                {
+                    "include": "#member-access-base"
+                },
+                {
+                    "include": "#member-access-property"
+                }
+            ]
+        },
+        "member-access-base": {
+            "patterns": [
+                {
+                    "include": "#illegal-name"
+                },
+                {
+                    "include": "#builtin-constant"
+                },
+                {
+                    "include": "#constant-identifier"
+                },
+                {
+                    "include": "#type-identifier"
+                },
+                {
+                    "include": "#line-continuation"
+                },
+                {
+                    "include": "#subscript-expression"
+                }
+            ]
+        },
+        "member-access-property": {
+            "match": "\\b([[:alpha:]_]\\w*)\\b",
+            "name": "variable.other.property.starlark"
+        },
+        "constant-identifier": {
+            "name": "variable.other.constant.starlark",
+            "match": "\\b_*[[:upper:]][[:upper:]\\d]*(_\\w*)?\\b"
+        },
+        "type-identifier": {
+            "name": "entity.name.type.starlark",
+            "match": "\\b_*[[:upper:]][[:alpha:]\\d]*(_\\w*)?\\b"
+        },
+        "dictionary-literal": {
+            "comment": "This also currently covers comprehensions.",
+            "begin": "\\{",
+            "end": "\\}",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.dict.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.dict.end.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#expression"
+                }
+            ]
+        },
+        "list-literal": {
+            "comment": "This also currently covers comprehensions.",
+            "begin": "\\[",
+            "end": "\\]",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.list.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.list.end.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#expression"
+                }
+            ]
+        },
+        "parenthesized-expression": {
+            "comment": "This covers tuples and parenthesized expressions.",
+            "begin": "\\(",
+            "end": "\\)",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.parenthesis.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.parenthesis.end.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#expression"
+                }
+            ]
+        },
+        "line-continuation": {
+            "patterns": [
+                {
+                    "match": "(\\\\)\\s*(\\S.*$\\n?)",
+                    "captures": {
+                        "1": {
+                            "name": "invalid.deprecated.continuation.line.starlark"
+                        },
+                        "2": {
+                            "name": "invalid.illegal.line.continuation.starlark"
+                        }
+                    }
+                },
+                {
+                    "begin": "(\\\\)\\s*$\\n?",
+                    "end": "(?=^\\s*$)|(?!(\\s*[rR]?('''|\"\"\"|'|\"))|(\\G$))",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "invalid.deprecated.continuation.line.starlark"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#string"
+                        }
+                    ]
+                }
+            ]
+        },
+        "assignment-operator": {
+            "name": "keyword.operator.assignment.starlark",
+            "match": "//=|\\+=|-=|/=|\\*=|%=|=(?!=)"
+        },
+        "operator": {
+            "match": "\\b(?<!\\.)(?:(and|or|not|in)(?# 1)|(for|if|else)(?# 2))(?!\\s*:)\\b|(\\*|\\+|-|%|//|/)(?# 3)|(!=|==|>=|<=|<|>)(?# 4)",
+            "captures": {
+                "1": {
+                    "name": "keyword.operator.logical.starlark"
+                },
+                "2": {
+                    "name": "keyword.control.flow.starlark"
+                },
+                "3": {
+                    "name": "keyword.operator.arithmetic.starlark"
+                },
+                "4": {
+                    "name": "keyword.operator.comparison.starlark"
+                }
+            }
+        },
+        "literal": {
+            "patterns": [
+                {
+                    "name": "constant.language.starlark",
+                    "match": "\\b(True|False|None)\\b"
+                },
+                {
+                    "include": "#number"
+                }
+            ]
+        },
+        "number": {
+            "patterns": [
+                {
+                    "include": "#number-decimal"
+                },
+                {
+                    "include": "#number-hexadecimal"
+                },
+                {
+                    "include": "#number-octal"
+                },
+                {
+                    "name": "invalid.illegal.name.starlark",
+                    "match": "\\b[0-9]+\\w+"
+                }
+            ]
+        },
+        "number-decimal": {
+            "name": "constant.numeric.decimal.starlark",
+            "match": "(?<![\\w\\.])(?:[1-9][0-9]*|0+)\\b"
+        },
+        "number-hexadecimal": {
+            "name": "constant.numeric.hex.starlark",
+            "match": "(?<![\\w\\.])0[xX][0-9a-fA-F]+\\b"
+        },
+        "number-octal": {
+            "name": "constant.numeric.octal.starlark",
+            "match": "(?<![\\w\\.])0[oO][0-7]+\\b"
+        },
+        "string": {
+            "patterns": [
+                {
+                    "include": "#string-raw-quoted-multi-line"
+                },
+                {
+                    "include": "#string-raw-quoted-single-line"
+                },
+                {
+                    "include": "#string-quoted-multi-line"
+                },
+                {
+                    "include": "#string-quoted-single-line"
+                }
+            ]
+        },
+        "string-raw-quoted-single-line": {
+            "name": "string.quoted.raw.single.starlark",
+            "begin": "\\b(r)(['\"])",
+            "end": "(\\2)|((?<!\\\\)\\n)",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.string.starlark"
+                },
+                "2": {
+                    "name": "punctuation.definition.string.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.end.starlark"
+                },
+                "2": {
+                    "name": "invalid.illegal.newline.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#string-raw-content"
+                }
+            ]
+        },
+        "string-quoted-single-line": {
+            "name": "string.quoted.single.starlark",
+            "begin": "(['\"])",
+            "end": "(\\1)|((?<!\\\\)\\n)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.end.starlark"
+                },
+                "2": {
+                    "name": "invalid.illegal.newline.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#string-content"
+                }
+            ]
+        },
+        "string-raw-quoted-multi-line": {
+            "name": "string.quoted.raw.multi.starlark",
+            "begin": "\\b(r)('''|\"\"\")",
+            "end": "(\\2)",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.string.starlark"
+                },
+                "2": {
+                    "name": "punctuation.definition.string.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.end.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#string-raw-content"
+                }
+            ]
+        },
+        "string-quoted-multi-line": {
+            "name": "string.quoted.multi.starlark",
+            "begin": "('''|\"\"\")",
+            "end": "(\\1)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.end.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#string-content"
+                }
+            ]
+        },
+        "string-content": {
+            "patterns": [
+                {
+                    "include": "#string-escape-sequence"
+                },
+                {
+                    "include": "#string-illegal-escape-sequence"
+                },
+                {
+                    "include": "#discouraged-string-line-continuation"
+                },
+                {
+                    "include": "#string-format-placeholder-percent"
+                },
+                {
+                    "include": "#string-format-placeholder-braces"
+                }
+            ]
+        },
+        "string-raw-content": {
+            "patterns": [
+                {
+                    "include": "#string-consume-escape"
+                },
+                {
+                    "include": "#string-format-placeholder-percent"
+                },
+                {
+                    "include": "#string-format-placeholder-braces"
+                }
+            ]
+        },
+        "string-consume-escape": {
+            "match": "\\\\['\"\\n\\\\]"
+        },
+        "string-escape-sequence": {
+            "name": "constant.character.escape.starlark",
+            "match": "\\\\[\\\\\"'nrt]"
+        },
+        "string-illegal-escape-sequence": {
+            "name": "invalid.illegal.character.escape.starlark",
+            "match": "\\\\[^\\\\\"'nrt]"
+        },
+        "string-format-placeholder-percent": {
+            "name": "constant.character.format.placeholder.other.starlark",
+            "match": "%[drs%]"
+        },
+        "string-format-placeholder-braces": {
+            "patterns": [
+                {
+                    "name": "constant.character.format.placeholder.other.starlark",
+                    "match": "\\{(?:[0-9]+|[[:alpha:]_][[:alnum:]_]*)?\\}"
+                }
+            ]
+        },
+        "function-definition": {
+            "name": "meta.function.starlark",
+            "begin": "\\s*\\b(def)\\s+(?=[[:alpha:]_][[:word:]]*\\s*\\()",
+            "end": "(:|(?=[#'\"\\n]))",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.function.starlark"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.function.begin.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#function-definition-name"
+                },
+                {
+                    "include": "#function-definition-parameters"
+                },
+                {
+                    "include": "#line-continuation"
+                }
+            ]
+        },
+        "function-definition-name": {
+            "patterns": [
+                {
+                    "include": "#builtin-constant"
+                },
+                {
+                    "include": "#illegal-name"
+                },
+                {
+                    "include": "#builtin-function"
+                },
+                {
+                    "name": "entity.name.function.starlark",
+                    "match": "\\b([[:alpha:]_]\\w*)\\b"
+                }
+            ]
+        },
+        "function-definition-parameters": {
+            "name": "meta.function.parameters.starlark",
+            "begin": "(\\()",
+            "end": "(\\))",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.parameters.begin.starlark"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.parameters.end.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "name": "keyword.operator.unpacking.parameter.starlark",
+                    "match": "(\\*\\*|\\*)"
+                },
+                {
+                    "include": "#illegal-name"
+                },
+                {
+                    "include": "#builtin-constant"
+                },
+                {
+                    "match": "([[:alpha:]_]\\w*)\\s*(?:(,)|(?=[)#\\n=]))",
+                    "captures": {
+                        "1": {
+                            "name": "variable.parameter.starlark"
+                        },
+                        "2": {
+                            "name": "punctuation.separator.parameters.starlark"
+                        }
+                    }
+                },
+                {
+                    "include": "#line-comment"
+                },
+                {
+                    "include": "#function-definition-parameter-default-value"
+                }
+            ]
+        },
+        "function-definition-parameter-default-value": {
+            "begin": "(=)",
+            "end": "(,)|(?=\\))",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.operator.starlark"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.separator.parameters.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#expression"
+                }
+            ]
+        },
+        "subscript-expression": {
+            "patterns": [
+                {
+                    "name": "meta.item-access.starlark",
+                    "begin": "\\b(?=[[:alpha:]_]\\w*\\s*\\[)",
+                    "end": "(\\])",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.arguments.end.starlark"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#subscript-receiver"
+                        },
+                        {
+                            "include": "#subscript-index"
+                        },
+                        {
+                            "include": "#expression"
+                        }
+                    ]
+                }
+            ]
+        },
+        "subscript-receiver": {
+            "patterns": [
+                {
+                    "include": "#builtin-function"
+                },
+                {
+                    "include": "#constant-identifier"
+                },
+                {
+                    "name": "variable.other.starlark",
+                    "match": "\\b([[:alpha:]_]\\w*)\\b"
+                }
+            ]
+        },
+        "subscript-index": {
+            "begin": "(\\[)",
+            "end": "(?=\\])",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.arguments.begin.starlark"
+                }
+            },
+            "contentName": "meta.item-access.arguments.starlark",
+            "patterns": [
+                {
+                    "include": "#expression"
+                }
+            ]
+        },
+        "function-call": {
+            "name": "meta.function-call.starlark",
+            "begin": "\\b(?=([[:alpha:]_]\\w*)\\s*(\\())",
+            "end": "(\\))",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.arguments.end.starlark"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#function-call-name"
+                },
+                {
+                    "include": "#function-arguments"
+                }
+            ]
+        },
+        "function-call-name": {
+            "patterns": [
+                {
+                    "include": "#type-identifier"
+                },
+                {
+                    "include": "#builtin-function"
+                },
+                {
+                    "name": "entity.name.function.starlark",
+                    "match": "\\b([[:alpha:]_]\\w*)\\b"
+                }
+            ]
+        },
+        "function-arguments": {
+            "begin": "(?:(\\()(?:\\s*(\\*\\*|\\*))?)",
+            "end": "(?=\\))(?!\\)\\s*\\()",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.arguments.begin.starlark"
+                },
+                "2": {
+                    "name": "keyword.operator.unpacking.arguments.starlark"
+                }
+            },
+            "contentName": "meta.function-call.arguments.starlark",
+            "patterns": [
+                {
+                    "match": "(?:(,)(?:\\s*(\\*\\*|\\*))?)",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.separator.arguments.starlark"
+                        },
+                        "2": {
+                            "name": "keyword.operator.unpacking.arguments.starlark"
+                        }
+                    }
+                },
+                {
+                    "include": "#illegal-name"
+                },
+                {
+                    "match": "\\b([[:alpha:]_]\\w*)\\s*(=)(?!=)",
+                    "captures": {
+                        "1": {
+                            "name": "meta.parameter.keyword.starlark"
+                        },
+                        "2": {
+                            "name": "keyword.operator.assignment.starlark"
+                        }
+                    }
+                },
+                {
+                    "name": "keyword.operator.assignment.starlark",
+                    "match": "=(?!=)"
+                },
+                {
+                    "include": "#expression"
+                },
+                {
+                    "match": "\\s*(\\))\\s*(\\()",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.arguments.end.starlark"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.arguments.begin.starlark"
+                        }
+                    }
+                }
+            ]
+        },
+        "builtin-function": {
+            "patterns": [
+                {
+                    "name": "support.function.starlark",
+                    "match": "(?<!\\.)\\b(all|any|bool|dict|dir|enumerate|getattr|hasattr|hash|int|len|list|load|max|min|print|range|repr|reversed|sorted|str|tuple|type|zip)\\b"
+                }
+            ]
+        },
+        "builtin-constant": {
+            "name": "keyword.illegal.name.starlark",
+            "match": "\\b(True|False|None)\\b"
+        },
+        "illegal-name": {
+            "name": "keyword.control.flow.starlark",
+            "match": "\\b(and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|load|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
+        },
+        "illegal-operator": {
+            "patterns": [
+                {
+                    "name": "invalid.illegal.operator.starlark",
+                    "match": "&&|\\|\\||--|\\+\\+"
+                },
+                {
+                    "name": "invalid.illegal.operator.starlark",
+                    "match": "[?$]"
+                },
+                {
+                    "name": "invalid.illegal.operator.starlark",
+                    "match": "!\\b"
+                }
+            ]
+        },
+        "line-comment": {
+            "name": "comment.line.number-sign.starlark",
+            "begin": "(\\#)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.comment.starlark"
+                }
+            },
+            "end": "($)",
+            "patterns": [
+                {
+                    "include": "#code-tag"
+                }
+            ]
+        },
+        "code-tag": {
+            "match": "(?:\\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\\b)",
+            "captures": {
+                "1": {
+                    "name": "keyword.codetag.notation.starlark"
+                }
+            }
+        },
+       "discouraged-semicolon": {
+            "patterns": [
+                {
+                    "name": "invalid.deprecated.semicolon.starlark",
+                    "match": "\\;$"
+                }
+            ]
+        },
+        "discouraged-string-line-continuation": {
+            "name": "invalid.deprecated.language.starlark",
+            "match": "\\\\$"
+        }
+    }
+}

--- a/syntaxes/starlark.tmLanguage.license
+++ b/syntaxes/starlark.tmLanguage.license
@@ -1,0 +1,26 @@
+starlark.tmLanguage.json is derived from MagicPython.tmLanguage.json,
+which can be found at https://github.com/MagicStack/MagicPython.
+
+---
+
+The MIT License
+
+Copyright (c) 2015 MagicStack Inc.  http://magic.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
This took longer than I hoped, since I kept getting pulled away to work on other things. The main goal here was to do more than just copy the MagicPython grammar, but to strip it down to just what we needed for Starlark (and to add a couple additional enhancements to bring it up to a similar level of highlighting that VS Code uses for other languages).