### PR TITLE
Add context menu items to the workspace tree.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
     ],
     "main": "./out/src/extension/extension",
     "contributes": {
+        "commands": [
+            {
+                "command": "bazel.buildTarget",
+                "title": "Build Target"
+            },
+            {
+                "command": "bazel.testTarget",
+                "title": "Test Target"
+            }
+        ],
         "configuration": {
             "type": "object",
             "title": "Bazel",
@@ -54,6 +64,25 @@
                 "configuration": "./syntaxes/starlark.configuration.json"
             }
         ],
+        "menus": {
+            "view/item/context": [
+                {
+                    "command": "bazel.buildTarget",
+                    "when": "view == bazelWorkspace && viewItem == rule",
+                    "group": "build"
+                },
+                {
+                    "command": "bazel.buildTarget",
+                    "when": "view == bazelWorkspace && viewItem == testRule",
+                    "group": "build"
+                },
+                {
+                    "command": "bazel.testTarget",
+                    "when": "view == bazelWorkspace && viewItem == testRule",
+                    "group": "build"
+                }
+            ]
+        },
         "views": {
             "explorer": [
                 {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from 'vscode';
 import { BazelWorkspaceTreeProvider } from '../workspace-tree/workspace-tree';
+import { BazelBuild, BazelCommandAdapter, BazelTest } from '../bazel/commands';
 
 /**
  * Called when the extension is activated; that is, when its first command is executed.
@@ -22,9 +23,38 @@ import { BazelWorkspaceTreeProvider } from '../workspace-tree/workspace-tree';
  */
 export function activate(context: vscode.ExtensionContext) {
   let workspaceTreeProvider = new BazelWorkspaceTreeProvider(context);
+
   context.subscriptions.push(
-    vscode.window.registerTreeDataProvider('bazelWorkspace', workspaceTreeProvider));
+    vscode.window.registerTreeDataProvider("bazelWorkspace", workspaceTreeProvider),
+    // Commands
+    vscode.commands.registerCommand("bazel.buildTarget", bazelBuildTarget),
+    vscode.commands.registerCommand("bazel.testTarget", bazelTestTarget),
+  );
 }
 
 /** Called when the extension is deactivated. */
 export function deactivate() { }
+
+/**
+ * Builds a Bazel target and streams output to the terminal.
+ * 
+ * @param adapter An object that implements {@link BazelCommandAdapter} from which the command's
+ *     arguments will be determined.
+ */
+function bazelBuildTarget(adapter: BazelCommandAdapter) {
+  const args = adapter.getBazelCommandArgs();
+  const command = new BazelBuild(args.workingDirectory, args.options);
+  command.run();
+}
+
+/**
+ * Tests a Bazel target and streams output to the terminal.
+ *
+ * @param adapter An object that implements {@link BazelCommandAdapter} from which the command's
+ *     arguments will be determined.
+ */
+function bazelTestTarget(adapter: BazelCommandAdapter) {
+  const args = adapter.getBazelCommandArgs();
+  const command = new BazelTest(args.workingDirectory, args.options);
+  command.run();
+}


### PR DESCRIPTION
This adds "Build Target" as a menu item for all targets, and "Test Target" to
targets whose rule names end in "_test".