### PR TITLE
Watch BUILD files for changes to refresh CodeLenses.

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -31,6 +31,7 @@ import { BazelWorkspaceTreeProvider } from "../workspace-tree";
  */
 export function activate(context: vscode.ExtensionContext) {
   const workspaceTreeProvider = new BazelWorkspaceTreeProvider(context);
+  const codeLensProvider = new BazelBuildCodeLensProvider(context);
 
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider(
@@ -47,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
     // CodeLens provider for BUILD files
     vscode.languages.registerCodeLensProvider(
       [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
-      new BazelBuildCodeLensProvider(),
+      codeLensProvider,
     ),
   );
 }


### PR DESCRIPTION
In addition to updating on file changes, we clear out the lenses when a
file is being edited (i.e., dirty). This is because the lenses don't
automatically move with edits (a more robust language server would be
needed to handle this), and we can't accurately determine the build
targets in an edited BUILD file until it's been saved and we can run the
query again.