### PR TITLE
Add category strings to Bazel commands.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,17 @@
         ],
         "commands": [
             {
+                "category": "Bazel",
                 "command": "bazel.buildTarget",
                 "title": "Build Target"
             },
             {
+                "category": "Bazel",
                 "command": "bazel.buildTargetWithDebugging",
                 "title": "Build Target with Debugging"
             },
             {
+                "category": "Bazel",
                 "command": "bazel.testTarget",
                 "title": "Test Target"
             }


### PR DESCRIPTION
This ensures that they show up in the command palette like "Bazel: Build
Target" instead of just "Build Target".