### PR TITLE
Symbol provider for bazel rules

### DIFF
--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -15,6 +15,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import { BazelQuery, QueryResult } from ".";
+
 /**
  * Search for the path to the directory that has the Bazel WORKSPACE file for
  * the given file.
@@ -44,4 +46,35 @@ export function getBazelWorkspaceFolder(fsPath: string): string | undefined {
   } while (dirname !== "");
 
   return undefined;
+}
+
+/**
+ * Get the targets in the build file
+ *
+ * @param workspace The path to the workspace
+ * @param buildFile The path to the build file
+ * @returns A query result for targets in the build file
+ */
+export async function getTargetsForBuildFile(
+  workspace: string,
+  buildFile: string,
+): Promise<QueryResult> {
+  // Path to the BUILD file relative to the workspace.
+  const relPathToDoc = path.relative(workspace, buildFile);
+  // Strip away the name of the BUILD file from the relative path.
+  let relDirWithDoc = path.dirname(relPathToDoc);
+  // Strip away the "." if the BUILD file was in the same directory as the
+  // workspace.
+  if (relDirWithDoc === ".") {
+    relDirWithDoc = "";
+  }
+  // Turn the relative path into a package label
+  const pkg = `//${relDirWithDoc}`;
+  const queryResult = await new BazelQuery(
+    workspace,
+    `'kind(rule, ${pkg}:all)'`,
+    [],
+  ).runAndParse();
+
+  return queryResult;
 }

--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -17,7 +17,7 @@ import * as path from "path";
 
 import { blaze_query } from "../protos";
 
-import { BazelQuery } from ".";
+import { BazelQuery } from "./bazel_query";
 
 /**
  * Search for the path to the directory that has the Bazel WORKSPACE file for

--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -15,7 +15,9 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { BazelQuery, QueryResult } from ".";
+import { blaze_query } from "../protos";
+
+import { BazelQuery } from ".";
 
 /**
  * Search for the path to the directory that has the Bazel WORKSPACE file for
@@ -58,7 +60,7 @@ export function getBazelWorkspaceFolder(fsPath: string): string | undefined {
 export async function getTargetsForBuildFile(
   workspace: string,
   buildFile: string,
-): Promise<QueryResult> {
+): Promise<blaze_query.QueryResult> {
   // Path to the BUILD file relative to the workspace.
   const relPathToDoc = path.relative(workspace, buildFile);
   // Strip away the name of the BUILD file from the relative path.
@@ -74,7 +76,7 @@ export async function getTargetsForBuildFile(
     workspace,
     `'kind(rule, ${pkg}:all)'`,
     [],
-  ).runAndParse();
+  ).queryTargets();
 
   return queryResult;
 }

--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as path from "path";
 import * as vscode from "vscode";
-import { BazelQuery, getBazelWorkspaceFolder, QueryLocation } from "../bazel";
+
+import {
+  getBazelWorkspaceFolder,
+  getTargetsForBuildFile,
+  QueryLocation,
+} from "../bazel";
 import { blaze_query } from "../protos";
+
 import { CodeLensCommandAdapter } from "./code_lens_command_adapter";
 
 /** Provids CodeLenses for targets in Bazel BUILD files. */
@@ -74,22 +79,10 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
       );
       return [];
     }
-    // Path to the BUILD file relative to the workspace.
-    const relPathToDoc = path.relative(workspace, document.uri.fsPath);
-    // Strip away the name of the BUILD file from the relative path.
-    let relDirWithDoc = path.dirname(relPathToDoc);
-    // Strip away the "." if the BUILD file was in the same directory as the
-    // workspace.
-    if (relDirWithDoc === ".") {
-      relDirWithDoc = "";
-    }
-    // Turn the relative path into a package label
-    const pkg = `//${relDirWithDoc}`;
-    const queryResult = await new BazelQuery(
+    const queryResult = await getTargetsForBuildFile(
       workspace,
-      `'kind(rule, ${pkg}:all)'`,
-      [],
-    ).queryTargets();
+      document.uri.fsPath,
+    );
 
     return this.computeCodeLenses(workspace, queryResult);
   }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -28,7 +28,7 @@ import {
   getDefaultBuildifierExecutablePath,
 } from "../buildifier";
 import { BazelBuildCodeLensProvider } from "../codelens";
-import { StarlarkSymbolProvider } from "../symbols";
+import { BazelTargetSymbolProvider } from "../symbols";
 import { BazelWorkspaceTreeProvider } from "../workspace-tree";
 
 /**
@@ -74,13 +74,8 @@ export function activate(context: vscode.ExtensionContext) {
     buildifierDiagnostics,
     // Symbol provider for BUILD files
     vscode.languages.registerDocumentSymbolProvider(
-      [
-        { pattern: "**/BUILD" },
-        { pattern: "**/BUILD.bazel" },
-        { pattern: "**/*.bzl" },
-        { pattern: "**/*.sky" },
-      ],
-      new StarlarkSymbolProvider(),
+      [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
+      new BazelTargetSymbolProvider(),
     ),
   );
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import * as which from "which";
+
 import {
   BazelBuild,
   BazelTest,
@@ -27,6 +28,7 @@ import {
   getDefaultBuildifierExecutablePath,
 } from "../buildifier";
 import { BazelBuildCodeLensProvider } from "../codelens";
+import { StarlarkSymbolProvider } from "../symbols";
 import { BazelWorkspaceTreeProvider } from "../workspace-tree";
 
 /**
@@ -70,6 +72,16 @@ export function activate(context: vscode.ExtensionContext) {
       new BuildifierFormatProvider(),
     ),
     buildifierDiagnostics,
+    // Symbol provider for BUILD files
+    vscode.languages.registerDocumentSymbolProvider(
+      [
+        { pattern: "**/BUILD" },
+        { pattern: "**/BUILD.bazel" },
+        { pattern: "**/*.bzl" },
+        { pattern: "**/*.sky" },
+      ],
+      new StarlarkSymbolProvider(),
+    ),
   );
 
   // Notify the user if buildifier is not available on their path (or where

--- a/src/symbols/bazel_build_symbol_provider.ts
+++ b/src/symbols/bazel_build_symbol_provider.ts
@@ -1,0 +1,84 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as vscode from "vscode";
+import { DocumentSymbolProvider } from "vscode";
+
+import {
+  getBazelWorkspaceFolder,
+  getTargetsForBuildFile,
+  QueryResult,
+} from "../bazel";
+
+/** Provids Symbols for targets in Bazel BUILD files. */
+export class StarlarkSymbolProvider implements DocumentSymbolProvider {
+  public async provideDocumentSymbols(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken,
+  ): Promise<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
+    const workspace = getBazelWorkspaceFolder(document.uri.fsPath);
+    if (workspace === undefined) {
+      vscode.window.showWarningMessage(
+        "Bazel BUILD Symbols unavailable as currently opened file is not in " +
+          "a Bazel workspace",
+      );
+      return [];
+    }
+
+    const queryResult = await getTargetsForBuildFile(
+      workspace,
+      document.uri.fsPath,
+    );
+
+    return this.computeSymbols(queryResult);
+  }
+
+  /**
+   * Takes the result of a Bazel query for targets defined in a package and
+   * returns a list of Symbols for the BUILD file in that package.
+   *
+   * @param queryResult The result of the bazel query.
+   */
+  private computeSymbols(queryResult: QueryResult): vscode.DocumentSymbol[] {
+    const result = [];
+
+    for (const rule of queryResult.rules) {
+      const loc = rule.location;
+      const target = rule.name;
+
+      const colonIndex = target.indexOf(":");
+      let targetName: string;
+      if (colonIndex !== -1) {
+        targetName = target.substr(colonIndex + 1);
+      } else {
+        targetName = target;
+      }
+
+      const linePosition = new vscode.Position(loc.line, 0);
+      const lineRangeStart = new vscode.Range(linePosition, linePosition);
+
+      result.push(
+        new vscode.DocumentSymbol(
+          targetName,
+          "",
+          vscode.SymbolKind.Function,
+          lineRangeStart,
+          lineRangeStart,
+        ),
+      );
+    }
+
+    return result;
+  }
+}

--- a/src/symbols/bazel_target_symbol_provider.ts
+++ b/src/symbols/bazel_target_symbol_provider.ts
@@ -23,7 +23,7 @@ import {
 import { blaze_query } from "../protos";
 
 /** Provids Symbols for targets in Bazel BUILD files. */
-export class StarlarkSymbolProvider implements DocumentSymbolProvider {
+export class BazelTargetSymbolProvider implements DocumentSymbolProvider {
   public async provideDocumentSymbols(
     document: vscode.TextDocument,
     token: vscode.CancellationToken,

--- a/src/symbols/index.ts
+++ b/src/symbols/index.ts
@@ -1,0 +1,1 @@
+export * from "./bazel_build_symbol_provider";

--- a/src/symbols/index.ts
+++ b/src/symbols/index.ts
@@ -1,1 +1,1 @@
-export * from "./bazel_build_symbol_provider";
+export * from "./bazel_target_symbol_provider";


### PR DESCRIPTION
Provide a [Go to symbol](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-symbol) capability for navigating rules within a BUILD file