### PR TITLE
Fix CodeLens titles after switching to query protos.

### DIFF
--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -118,8 +118,8 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
             new CodeLensCommandAdapter(bazelWorkspaceDirectory, [targetName]),
           ],
           command: "bazel.testTarget",
-          title: `Test ${target}`,
-          tooltip: `Build ${target}`,
+          title: `Test ${targetName}`,
+          tooltip: `Test ${targetName}`,
         };
       } else {
         cmd = {
@@ -127,8 +127,8 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
             new CodeLensCommandAdapter(bazelWorkspaceDirectory, [targetName]),
           ],
           command: "bazel.buildTarget",
-          title: `Build ${target}`,
-          tooltip: `Build ${target}`,
+          title: `Build ${targetName}`,
+          tooltip: `Build ${targetName}`,
         };
       }
       result.push(new vscode.CodeLens(location.range, cmd));


### PR DESCRIPTION
This was causing "Build [object Object]" to show up instead of the target name.