### PR TITLE
Explicitly use --mode=fix

### DIFF
--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -39,7 +39,7 @@ export async function buildifierFormat(
   type: BuildifierFileType,
   applyLintFixes: boolean,
 ): Promise<string> {
-  const args = [`--type=${type}`];
+  const args = [`--mode=fix`, `--type=${type}`];
   if (applyLintFixes) {
     args.push(`--lint=fix`);
   }


### PR DESCRIPTION
bazelbuild/buildtools#453 could get fixed in making the default for formatting
be to not do anything if a --lint mode is enabled, so be explicit about wanting
fix mode for formatting just to be safe.