### PR TITLE
Various debugger fixes.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,25 @@
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
             "preLaunchTask": "npm"
+        },
+        {
+            "name": "Launch Debug Server",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/src/debug-adapter/client.ts",
+            "args": ["--server=4711"],
+            "sourceMaps": true,
+            "outFiles": ["${workspaceRoot}/out/src/**/*.js"]
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Extension and Debug Server",
+            "configurations": [
+                "Launch Extension",
+                "Launch Debug Server"
+            ]
         }
     ]
 }

--- a/src/debug-adapter/connection.ts
+++ b/src/debug-adapter/connection.ts
@@ -168,7 +168,9 @@ export class BazelDebugConnection extends EventEmitter {
 
       this.collapse();
 
-      if (event.sequenceNumber !== 0) {
+      // Do the right thing whether the sequence number comes in as either a
+      // number or a Long (which is an object with separate low/high ints.)
+      if (event.sequenceNumber.toString() !== "0") {
         const handler = this.pendingResolvers.get(
           event.sequenceNumber.toString(),
         );


### PR DESCRIPTION
- Handle file paths correctly for breakpoints.
- Don't cause an exception if the debugger tries to get the frames of an unpaused thread.
- Don't drop events when the sequence number is a Long zero.

Fixes #24.