### PR TITLE
Add *.BUILD formatting

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -73,6 +73,7 @@ export function activate(context: vscode.ExtensionContext) {
         { pattern: "**/BUILD.bazel" },
         { pattern: "**/WORKSPACE" },
         { pattern: "**/WORKSPACE.bazel" },
+        { pattern: "**/*.BUILD" },
         { pattern: "**/*.bzl" },
         { pattern: "**/*.sky" },
       ],


### PR DESCRIPTION
https://docs.bazel.build/versions/master/external.html#depending-on-non-bazel-projects
Add formatting support for *.BUILD build files. Particularly useful for depending on non-Bazel projects.