### PR TITLE
Add support for build/testing packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,28 @@
             },
             {
                 "category": "Bazel",
+                "command": "bazel.buildAll",
+                "title": "Build Package"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.buildAllRecursive",
+                "title": "Build Package Recursively"
+            },
+            {
+                "category": "Bazel",
                 "command": "bazel.testTarget",
                 "title": "Test Target"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.testAll",
+                "title": "Test Package"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.testAllRecursive",
+                "title": "Test Package Recursively"
             },
             {
                 "category": "Bazel",
@@ -180,8 +200,28 @@
                     "group": "build"
                 },
                 {
+                    "command": "bazel.buildAll",
+                    "when": "view == bazelWorkspace && viewItem == package",
+                    "group": "build"
+                },
+                {
+                    "command": "bazel.buildAllRecursive",
+                    "when": "view == bazelWorkspace && viewItem == package",
+                    "group": "build"
+                },
+                {
                     "command": "bazel.testTarget",
                     "when": "view == bazelWorkspace && viewItem == testRule",
+                    "group": "build"
+                },
+                {
+                    "command": "bazel.testAll",
+                    "when": "view == bazelWorkspace && viewItem == package",
+                    "group": "build"
+                },
+                {
+                    "command": "bazel.testAllRecursive",
+                    "when": "view == bazelWorkspace && viewItem == package",
                     "group": "build"
                 }
             ],

--- a/src/bazel/bazel_exit_code.ts
+++ b/src/bazel/bazel_exit_code.ts
@@ -65,6 +65,8 @@ export function exitCodeToUserString(exitCode: ExitCode): string {
       return "Tests failed: check your test logs for errors.";
     case ExitCode.PARTIAL_ANALYSIS_FAILURE:
       return "Query failed: error during analysis.";
+    case ExitCode.NO_TESTS_FOUND:
+      return "No test targets were found.";
     case ExitCode.INTERRUPTED:
       return "Command interrupted.";
     case ExitCode.LOCK_HELD_NOBLOCK_FOR_LOCK:

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -13,13 +13,19 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
-import { BazelQuery, BazelWorkspaceInfo } from "../bazel";
+import {
+  BazelQuery,
+  BazelWorkspaceInfo,
+  IBazelCommandAdapter,
+  IBazelCommandOptions,
+} from "../bazel";
 import { blaze_query } from "../protos";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
 import { IBazelTreeItem } from "./bazel_tree_item";
 
 /** A tree item representing a build package. */
-export class BazelPackageTreeItem implements IBazelTreeItem {
+export class BazelPackageTreeItem
+  implements IBazelCommandAdapter, IBazelTreeItem {
   /**
    * The array of subpackages that should be shown directly under this package
    * item.
@@ -83,5 +89,13 @@ export class BazelPackageTreeItem implements IBazelTreeItem {
 
   public getContextValue(): string {
     return "package";
+  }
+
+  public getBazelCommandOptions(): IBazelCommandOptions {
+    return {
+      options: [],
+      targets: [`//${this.packagePath}`],
+      workspaceInfo: this.workspaceInfo,
+    };
   }
 }


### PR DESCRIPTION
- Add context command to the treeview on the packages to do build and testing
  of the package or the package resursively (:all vs /...).
- Includes a quickpick for generally using the command and selecting a package.

Mostly addresses #72, the limitation being the current UI doesn't really every
provide the "root" (the directory opened in VS Code) as a package, it just shows
the sub packages.