### PR TITLE
Improvements to package queries.

### DIFF
--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -62,7 +62,8 @@ export class BazelQuery extends BazelCommand {
    *
    * @param additionalOptions Additional command line options that should be
    *     passed just to this specific invocation of the query.
-   * @returns An array of package paths containing the targets that match.
+   * @returns An sorted array of package paths containing the targets that
+   *     match.
    */
   public async queryPackages(
     additionalOptions: string[] = [],
@@ -73,7 +74,8 @@ export class BazelQuery extends BazelCommand {
     const result = buffer
       .toString("utf-8")
       .trim()
-      .split("\n");
+      .split("\n")
+      .sort();
     return result;
   }
 

--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -97,10 +97,9 @@ async function queryWorkspaceQuickPickPackages(
 ): Promise<BazelTargetQuickPick[]> {
   const packagePaths = await new BazelQuery(
     workspaceInfo.bazelWorkspacePath,
-    "...",
-    ["--output=package"],
+    "...:*",
+    [],
   ).queryPackages();
-  packagePaths.sort();
   const result: BazelTargetQuickPick[] = [];
   for (const target of packagePaths) {
     result.push(new BazelTargetQuickPick("//" + target, workspaceInfo));

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -152,11 +152,11 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     // workspace without the performance penalty of querying the entire
     // workspace.
     const workspacePath = this.workspaceInfo.workspaceFolder.uri.fsPath;
-    const packagePaths = await new BazelQuery(workspacePath, "...", [
-      "--output=package",
-    ]).queryPackages();
-    packagePaths.sort();
-
+    const packagePaths = await new BazelQuery(
+      workspacePath,
+      "...:*",
+      [],
+    ).queryPackages();
     const topLevelItems: BazelPackageTreeItem[] = [];
     this.buildPackageTree(
       packagePaths,


### PR DESCRIPTION
- Always sort the result (callers were).
- Tweak the query so packages that are created by an empty BUILD file still
  get captured (done by using a query that catches the BUILD file target
  itself (it is exposed as a source file))

Fixes #79