### PR TITLE
Fixed an issue where the extension would hang on non-workspace directories.

### DIFF
--- a/src/bazel/bazel_workspace_info.ts
+++ b/src/bazel/bazel_workspace_info.ts
@@ -91,6 +91,11 @@ export class BazelWorkspaceInfo {
  */
 function getBazelWorkspaceFolder(fsPath: string): string | undefined {
   let dirname = fsPath;
+  let iteration = 0;
+  // Fail safe in case other file systems have a base dirname that doesn't
+  // match the checks below. Having this failsafe guarantees that we don't
+  // hang in an infinite loop.
+  const maxIterations = 100;
   if (fs.statSync(fsPath).isFile()) {
     dirname = path.dirname(dirname);
   }
@@ -105,7 +110,7 @@ function getBazelWorkspaceFolder(fsPath: string): string | undefined {
       // Intentionally do nothing; just try the next parent directory.
     }
     dirname = path.dirname(dirname);
-  } while (dirname !== "");
+  } while (++iteration < maxIterations && dirname !== "" && dirname !== "/");
 
   return undefined;
 }

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -151,6 +151,9 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     // have a VS Code workspace that is pointed at a subpackage of a large
     // workspace without the performance penalty of querying the entire
     // workspace.
+    if (!this.workspaceInfo) {
+      return Promise.resolve([]);
+    }
     const workspacePath = this.workspaceInfo.workspaceFolder.uri.fsPath;
     const packagePaths = await new BazelQuery(
       workspacePath,


### PR DESCRIPTION
The getBazelWorkspaceFolder() function would hang if the loop reached the base directory without encountering a WORKSPACE file. Fixed and tested it on MacOS. In addition, since I suspect this fix won't work for Windows (the base directory is probably different) I added a failsafe for other file systems.

This fix also exposed a problem in getDirectoryItems() if the workspace does not exist. Added the fix for that too.