### PR TITLE
Remove vscode dependency from bazel_command

### DIFF
--- a/src/bazel/bazel_command.ts
+++ b/src/bazel/bazel_command.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as vscode from "vscode";
 import { BazelWorkspaceInfo } from "./bazel_workspace_info";
 
 /**
@@ -48,12 +47,14 @@ export abstract class BazelCommand {
   /**
    * Initializes a new Bazel command instance.
    *
+   * @param bazelExecutable The path to the Bazel executable.
    * @param workingDirectory The path to the directory from which Bazel will be
    *     spawned.
    * @param options Command line options that will be passed to Bazel (targets,
    *     query strings, flags, etc.).
    */
   public constructor(
+    readonly bazelExecutable: string,
     readonly workingDirectory: string,
     readonly options: string[] = [],
   ) {}
@@ -66,7 +67,7 @@ export abstract class BazelCommand {
 
   /** The command line string used to execute the query. */
   protected commandLine(additionalOptions: string[] = []) {
-    let result = `${getDefaultBazelExecutablePath()} ${this.bazelCommand()}`;
+    let result = `${this.bazelExecutable} ${this.bazelCommand()}`;
     if (this.options.length > 0) {
       result += " ";
       result += this.options.join(" ");
@@ -77,23 +78,4 @@ export abstract class BazelCommand {
     }
     return result;
   }
-}
-
-/**
- * Gets the path to the Bazel executable specified by the workspace
- * configuration, if present.
- *
- * @returns The path to the Bazel executable specified in the workspace
- * configuration, or just "bazel" if not present (in which case the system path
- * will be searched).
- */
-export function getDefaultBazelExecutablePath(): string {
-  // Try to retrieve the executable from VS Code's settings. If it's not set,
-  // just use "bazel" as the default and get it from the system PATH.
-  const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  const bazelExecutable = bazelConfig.executable as string;
-  if (bazelExecutable.length === 0) {
-    return "bazel";
-  }
-  return bazelExecutable;
 }

--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -21,6 +21,7 @@ export class BazelQuery extends BazelCommand {
   /**
    * Initializes a new Bazel query.
    *
+   * @param bazelExecutable The path to the Bazel executable.
    * @param workingDirectory The path to the directory from which Bazel will be
    *     spawned.
    * @param query The query to execute.
@@ -31,12 +32,13 @@ export class BazelQuery extends BazelCommand {
    *     empty string instead.
    */
   public constructor(
+    bazelExecutable: string,
     workingDirectory: string,
     query: string,
     options: string[],
     private readonly ignoresErrors: boolean = false,
   ) {
-    super(workingDirectory, [query].concat(options));
+    super(bazelExecutable, workingDirectory, [query].concat(options));
   }
 
   /**

--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
+import { getDefaultBazelExecutablePath } from "../extension/configuration";
 import { IBazelCommandAdapter, IBazelCommandOptions } from "./bazel_command";
 import { BazelQuery } from "./bazel_query";
 import { BazelWorkspaceInfo } from "./bazel_workspace_info";
@@ -73,6 +74,7 @@ async function queryWorkspaceQuickPickTargets(
   query: string,
 ): Promise<BazelTargetQuickPick[]> {
   const queryResult = await new BazelQuery(
+    getDefaultBazelExecutablePath(),
     workspaceInfo.bazelWorkspacePath,
     query,
     [],
@@ -96,6 +98,7 @@ async function queryWorkspaceQuickPickPackages(
   workspaceInfo: BazelWorkspaceInfo,
 ): Promise<BazelTargetQuickPick[]> {
   const packagePaths = await new BazelQuery(
+    getDefaultBazelExecutablePath(),
     workspaceInfo.bazelWorkspacePath,
     "...:*",
     [],

--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -20,11 +20,13 @@ import { BazelQuery } from "./bazel_query";
 /**
  * Get the targets in the build file
  *
- * @param workspace The path to the workspace
- * @param buildFile The path to the build file
- * @returns A query result for targets in the build file
+ * @param bazelExecutable The path to the Bazel executable.
+ * @param workspace The path to the workspace.
+ * @param buildFile The path to the build file.
+ * @returns A query result for targets in the build file.
  */
 export async function getTargetsForBuildFile(
+  bazelExecutable: string,
   workspace: string,
   buildFile: string,
 ): Promise<blaze_query.QueryResult> {
@@ -40,6 +42,7 @@ export async function getTargetsForBuildFile(
   // Turn the relative path into a package label
   const pkg = `//${relDirWithDoc}`;
   const queryResult = await new BazelQuery(
+    bazelExecutable,
     workspace,
     `'kind(rule, ${pkg}:all)'`,
     [],

--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
-import {
-  getDefaultBazelExecutablePath,
-  IBazelCommandOptions,
-} from "./bazel_command";
+import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import { IBazelCommandOptions } from "./bazel_command";
 import { BazelTaskInfo, setBazelTaskInfo } from "./bazel_task_info";
 
 /**

--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
+
 import {
   BazelWorkspaceInfo,
   getTargetsForBuildFile,
   QueryLocation,
 } from "../bazel";
+import { getDefaultBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { CodeLensCommandAdapter } from "./code_lens_command_adapter";
 
@@ -79,6 +81,7 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     const queryResult = await getTargetsForBuildFile(
+      getDefaultBazelExecutablePath(),
       workspaceInfo.bazelWorkspacePath,
       document.uri.fsPath,
     );

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -1,0 +1,34 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as vscode from "vscode";
+
+/**
+ * Gets the path to the Bazel executable specified by the workspace
+ * configuration, if present.
+ *
+ * @returns The path to the Bazel executable specified in the workspace
+ * configuration, or just "bazel" if not present (in which case the system path
+ * will be searched).
+ */
+export function getDefaultBazelExecutablePath(): string {
+  // Try to retrieve the executable from VS Code's settings. If it's not set,
+  // just use "bazel" as the default and get it from the system PATH.
+  const bazelConfig = vscode.workspace.getConfiguration("bazel");
+  const bazelExecutable = bazelConfig.executable as string;
+  if (bazelExecutable.length === 0) {
+    return "bazel";
+  }
+  return bazelExecutable;
+}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -20,7 +20,6 @@ import {
   createBazelTask,
   exitCodeToUserString,
   getBazelTaskInfo,
-  getDefaultBazelExecutablePath,
   IBazelCommandAdapter,
   parseExitCode,
   queryQuickPickPackage,
@@ -35,6 +34,7 @@ import { BazelBuildCodeLensProvider } from "../codelens";
 import { setupLoggingOutputChannel } from "../logging";
 import { BazelTargetSymbolProvider } from "../symbols";
 import { BazelWorkspaceTreeProvider } from "../workspace-tree";
+import { getDefaultBazelExecutablePath } from "./configuration";
 
 /**
  * Called when the extension is activated; that is, when its first command is

--- a/src/symbols/bazel_target_symbol_provider.ts
+++ b/src/symbols/bazel_target_symbol_provider.ts
@@ -20,6 +20,7 @@ import {
   getTargetsForBuildFile,
   QueryLocation,
 } from "../bazel";
+import { getDefaultBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 
 /** Provids Symbols for targets in Bazel BUILD files. */
@@ -38,6 +39,7 @@ export class BazelTargetSymbolProvider implements DocumentSymbolProvider {
     }
 
     const queryResult = await getTargetsForBuildFile(
+      getDefaultBazelExecutablePath(),
       workspaceInfo.bazelWorkspacePath,
       document.uri.fsPath,
     );

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -19,6 +19,7 @@ import {
   IBazelCommandAdapter,
   IBazelCommandOptions,
 } from "../bazel";
+import { getDefaultBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
 import { IBazelTreeItem } from "./bazel_tree_item";
@@ -53,6 +54,7 @@ export class BazelPackageTreeItem
 
   public async getChildren(): Promise<IBazelTreeItem[]> {
     const queryResult = await new BazelQuery(
+      getDefaultBazelExecutablePath(),
       this.workspaceInfo.bazelWorkspacePath,
       `//${this.packagePath}:all`,
       [],

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import { BazelQuery, BazelWorkspaceInfo } from "../bazel";
+import { getDefaultBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { BazelPackageTreeItem } from "./bazel_package_tree_item";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
@@ -156,6 +157,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     }
     const workspacePath = this.workspaceInfo.workspaceFolder.uri.fsPath;
     const packagePaths = await new BazelQuery(
+      getDefaultBazelExecutablePath(),
       workspacePath,
       "...:*",
       [],
@@ -172,6 +174,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     // Now collect any targets in the directory also (this can fail since
     // there might not be a BUILD files at this level (but down levels)).
     const queryResult = await new BazelQuery(
+      getDefaultBazelExecutablePath(),
       workspacePath,
       `:all`,
       [],


### PR DESCRIPTION
bazel_command currently has a dependency on vscode for the Bazel executable path. This change is to remove that dependency by passing the executable path into the constructor of the BazelCommand class.

This has the following benefits:
1. This will allow us to eventually move the Bazel-specific logic into a separate library.
2. It makes the code more testable.