### PR TITLE
Fix error when user has multiple workspace folders open

### DIFF
--- a/src/workspace-tree/bazel_workspace_tree_provider.ts
+++ b/src/workspace-tree/bazel_workspace_tree_provider.ts
@@ -83,11 +83,17 @@ export class BazelWorkspaceTreeProvider
       // If the user has multiple workspace folders open, then show them as
       // individual top level items.
       return Promise.resolve(
-        vscode.workspace.workspaceFolders.map((folder) => {
-          return new BazelWorkspaceFolderTreeItem(
-            BazelWorkspaceInfo.fromWorkspaceFolder(folder),
-          );
-        }),
+        vscode.workspace.workspaceFolders
+          .map((folder) => {
+            const workspaceInfo = BazelWorkspaceInfo.fromWorkspaceFolder(
+              folder,
+            );
+            if (workspaceInfo) {
+              return new BazelWorkspaceFolderTreeItem(workspaceInfo);
+            }
+            return undefined;
+          })
+          .filter((folder) => folder !== undefined),
       );
     }
 


### PR DESCRIPTION
We try to create a `BazelWorkspaceFolderTreeItem` for every folder the user has opened regardless of whether those folders are Bazel WORKSPACE folders.
This fix will ignore non-Bazel folders when creating
 `BazelWorkspaceFolderTreeItem`s.