### PR TITLE
.bazelci: Remove dummy targets.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,10 +2,6 @@
 tasks:
   ubuntu1804:
     shell_commands:
-      # Buildkite expects to be able to build at least one target, so we create
-      # a dummy workspace here.
-      - echo 'workspace(name = "build_bazel_vscode_bazel_dummy")' > WORKSPACE
-      - echo 'filegroup(name = "dummy")' > BUILD
       # Install node_modules and then compile and check the code for lint
       # errors.
       - npm ci
@@ -16,5 +12,3 @@ tasks:
       # prettier will obey our tslint config, but it doesn't support
       # Typescript 3 yet.
       # (https://github.com/azz/prettier-tslint/issues/18)
-    build_targets:
-      - "//:dummy"


### PR DESCRIPTION
Tasks without any build_targets or test_targets are supported on Bazel CI now.