### PR TITLE
Add "starlark" language to formatting provider.

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -88,6 +88,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Buildifier formatting support
     vscode.languages.registerDocumentFormattingEditProvider(
       [
+        { language: "starlark"},
         { pattern: "**/BUILD" },
         { pattern: "**/BUILD.bazel" },
         { pattern: "**/WORKSPACE" },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -88,7 +88,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Buildifier formatting support
     vscode.languages.registerDocumentFormattingEditProvider(
       [
-        { language: "starlark"},
+        { language: "starlark" },
         { pattern: "**/BUILD" },
         { pattern: "**/BUILD.bazel" },
         { pattern: "**/WORKSPACE" },


### PR DESCRIPTION
If users have other starlark-ish files to format that don't meet the patterns here, there's no way to take advantage of the formatter. This enables using a file association in the workspace/user settings to format anything set as "starlark".