### PR TITLE
Drop the warnings when a file isn't in a WORKSPACE.

### DIFF
--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -70,10 +70,7 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
 
     const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
     if (workspaceInfo === undefined) {
-      vscode.window.showWarningMessage(
-        "Bazel BUILD CodeLens unavailable as currently opened file is not in " +
-          "a Bazel workspace",
-      );
+      // Not in a Bazel Workspace.
       return [];
     }
 

--- a/src/symbols/bazel_target_symbol_provider.ts
+++ b/src/symbols/bazel_target_symbol_provider.ts
@@ -28,10 +28,7 @@ export class BazelTargetSymbolProvider implements DocumentSymbolProvider {
   ): Promise<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
     const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
     if (workspaceInfo === undefined) {
-      vscode.window.showWarningMessage(
-        "Bazel BUILD Symbols unavailable as currently opened file is not in " +
-          "a Bazel workspace",
-      );
+      // Not in a Bazel Workspace.
       return [];
     }
 


### PR DESCRIPTION
These both triggered on BUILD files meaning you always got two alerts every
time, and you can't just ignore them, they happen every time you open a matching
file not in a workspace so they sorta get spammy.

Fixes #136