### PR TITLE
Add a setting to support disabling the building support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
                 },
                 "bazel.directoriesToIgnore": {
                     "type": "string",
+                    "scope": "application",
                     "default": "",
                     "description": "Regex of directors to ignore when trying to figure out if something is in a Bazel Workspace. This just impacts things that need a Bazel Workspace, BUILD/.bzl syntax and buildifier support still work."
                 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Show the VSCode-Bazel output channel when the Bazel extension initializes."
+                },
+                "bazel.directoriesToIgnore": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Regex of directors to ignore when trying to figure out if something is in a Bazel Workspace. This just impacts things that need a Bazel Workspace, BUILD/.bzl syntax and buildifier support still work."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -112,11 +112,11 @@
                     "default": false,
                     "description": "Show the VSCode-Bazel output channel when the Bazel extension initializes."
                 },
-                "bazel.directoriesToIgnore": {
+                "bazel.pathsToIgnore": {
                     "type": "string",
                     "scope": "application",
                     "default": "",
-                    "description": "Regex of directors to ignore when trying to figure out if something is in a Bazel Workspace. This just impacts things that need a Bazel Workspace, BUILD/.bzl syntax and buildifier support still work."
+                    "description": "Regex of paths to ignore when trying to figure out if a file is in a Bazel workspace. This impacts operations that require a workspace, like queries, but syntax highlighting and buildifier work regardless."
                 }
             }
         },

--- a/src/bazel/bazellib/bazel_utils.ts
+++ b/src/bazel/bazellib/bazel_utils.ts
@@ -57,22 +57,21 @@ export async function getTargetsForBuildFile(
  * Bazel Workspace.
  *
  * @param fsPath The path to a file in a Bazel workspace.
- * @returns true / false for if the path should be ignore(assumed not to
+ * @returns true / false for if the path should be ignore (assumed not to
  *     be in a workspace).
  */
 function shouldIgnorePath(fsPath: string): boolean {
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  const directoriesToIgnore = bazelConfig.directoriesToIgnore as string;
-  if (directoriesToIgnore.length === 0) {
+  const pathsToIgnore = bazelConfig.pathsToIgnore as string;
+  if (pathsToIgnore.length === 0) {
     return false;
   }
   try {
-    const regex = new RegExp(directoriesToIgnore);
+    const regex = new RegExp(pathsToIgnore);
     return regex.test(fsPath);
   } catch (err) {
     vscode.window.showErrorMessage(
-      "directoriesToIgnore setting isn't a valid regex: " +
-      escape(directoriesToIgnore));
+      "pathsToIgnore setting isn't a valid regex: " + escape(pathsToIgnore));
   }
   return false;
 }

--- a/src/bazel/bazellib/bazel_utils.ts
+++ b/src/bazel/bazellib/bazel_utils.ts
@@ -14,6 +14,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import * as vscode from "vscode";
 import { blaze_query } from "../../protos";
 import { BazelQuery } from "./bazel_query";
 
@@ -52,6 +53,31 @@ export async function getTargetsForBuildFile(
 }
 
 /**
+ * Check if a path should be ignored and not considered to be part of a
+ * Bazel Workspace.
+ *
+ * @param fsPath The path to a file in a Bazel workspace.
+ * @returns true / false for if the path should be ignore(assumed not to
+ *     be in a workspace).
+ */
+function shouldIgnorePath(fsPath: string): boolean {
+  const bazelConfig = vscode.workspace.getConfiguration("bazel");
+  const directoriesToIgnore = bazelConfig.directoriesToIgnore as string;
+  if (directoriesToIgnore.length === 0) {
+    return false;
+  }
+  try {
+    const regex = new RegExp(directoriesToIgnore);
+    return regex.test(fsPath);
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      "directoriesToIgnore setting isn't a valid regex: " +
+      escape(directoriesToIgnore));
+  }
+  return false;
+}
+
+/**
  * Search for the path to the directory that has the Bazel WORKSPACE file for
  * the given file.
  *
@@ -63,6 +89,9 @@ export async function getTargetsForBuildFile(
  *     others undefined.
  */
 export function getBazelWorkspaceFolder(fsPath: string): string | undefined {
+  if (shouldIgnorePath(fsPath)) {
+    return undefined;
+  }
   let dirname = fsPath;
   let iteration = 0;
   // Fail safe in case other file systems have a base dirname that doesn't


### PR DESCRIPTION
Mainly useful as a global setting (not per project), lets you disable some
WORKSPACE discovery/target treeview where but still support the other features
(buildifer, BUILD syntax support, etc.).