### PR TITLE
Change pathsToIgnore to be a list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,10 +113,14 @@
                     "description": "Show the VSCode-Bazel output channel when the Bazel extension initializes."
                 },
                 "bazel.pathsToIgnore": {
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
                     "scope": "application",
-                    "default": "",
-                    "description": "Regex of paths to ignore when trying to figure out if a file is in a Bazel workspace. This impacts operations that require a workspace, like queries, but syntax highlighting and buildifier work regardless."
+                    "default": [],
+                    "description": "A list of Regexs that when matched cause paths not to be checked for being in a WORKSPACE. This impacts operations that require a workspace, like queries, but syntax highlighting and buildifier work regardless."
                 }
             }
         },

--- a/src/bazel/bazellib/bazel_utils.ts
+++ b/src/bazel/bazellib/bazel_utils.ts
@@ -62,16 +62,17 @@ export async function getTargetsForBuildFile(
  */
 function shouldIgnorePath(fsPath: string): boolean {
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  const pathsToIgnore = bazelConfig.pathsToIgnore as string;
-  if (pathsToIgnore.length === 0) {
-    return false;
-  }
-  try {
-    const regex = new RegExp(pathsToIgnore);
-    return regex.test(fsPath);
-  } catch (err) {
-    vscode.window.showErrorMessage(
-      "pathsToIgnore setting isn't a valid regex: " + escape(pathsToIgnore));
+  const pathsToIgnore = bazelConfig.pathsToIgnore as [string];
+  for (const pathRegex of pathsToIgnore) {
+    try {
+      const regex = new RegExp(pathRegex);
+      if (regex.test(fsPath)) {
+        return true;
+      }
+    } catch (err) {
+      vscode.window.showErrorMessage(
+        "pathsToIgnore value isn't a valid regex: " + escape(pathRegex));
+    }
   }
   return false;
 }


### PR DESCRIPTION
Should make it easier if needing more than one thing.

The VSCode docs didn't seem to document this, but the UI supports it and other
extensions use it.