### PR TITLE
Add settings for startup options and command args.

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,24 @@
                     "scope": "application",
                     "default": [],
                     "description": "A list of Regexs that when matched cause paths not to be checked for being in a WORKSPACE. This impacts operations that require a workspace, like queries, but syntax highlighting and buildifier work regardless."
+                },
+                "bazel.commandLine.startupOptions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": [],
+                    "markdownDescription": "A list of [Bazel startup options](https://docs.bazel.build/versions/master/command-line-reference.html#startup-options) to use when building or running tests."
+                },
+                "bazel.commandLine.commandArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": [],
+                    "markdownDescription": "A list of Bazel command line options to use when building or running tests. From the [common options](https://docs.bazel.build/versions/master/command-line-reference.html#options-common-to-all-commands) and [build options](https://docs.bazel.build/versions/master/command-line-reference.html#build) (`test` honors all `build` options)."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
                     },
                     "uniqueItems": true,
                     "default": [],
-                    "markdownDescription": "A list of [Bazel startup options](https://docs.bazel.build/versions/master/command-line-reference.html#startup-options) to use when building or running tests."
+                    "markdownDescription": "A list of [Bazel startup options](https://docs.bazel.build/versions/master/command-line-reference.html#startup-options) to use when building, running tests, or cleaning."
                 },
                 "bazel.commandLine.commandArgs": {
                     "type": "array",

--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -30,19 +30,16 @@ function quotedOption(option: string): vscode.ShellQuotedString {
  *
  * @param command The Bazel command to execute.
  * @param options Describes the options used to launch Bazel.
- * @param addDefaults If the user's defaults startup and command args should be
- *     added.
  */
 export function createBazelTask(
   command: "build" | "clean" | "test",
   options: IBazelCommandOptions,
-  addDefaults = true,
 ): vscode.Task {
   const bazelConfigCmdLine = vscode.workspace.getConfiguration("bazel.commandLine");
-  const startupOptions: [string] =
-    (addDefaults ? bazelConfigCmdLine.startupOptions : []);
+  const startupOptions: [string] = bazelConfigCmdLine.startupOptions;
+  const addCommandArgs = command === "build" || command === "test";
   const commandArgs: [string] =
-    (addDefaults ? bazelConfigCmdLine.commandArgs : []);
+    (addCommandArgs ? bazelConfigCmdLine.commandArgs : []);
 
   const args = startupOptions
     .concat([command as string])

--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -30,12 +30,23 @@ function quotedOption(option: string): vscode.ShellQuotedString {
  *
  * @param command The Bazel command to execute.
  * @param options Describes the options used to launch Bazel.
+ * @param addDefaults If the user's defaults startup and command args should be
+ *     added.
  */
 export function createBazelTask(
   command: "build" | "clean" | "test",
   options: IBazelCommandOptions,
+  addDefaults = true,
 ): vscode.Task {
-  const args = [command as string]
+  const bazelConfigCmdLine = vscode.workspace.getConfiguration("bazel.commandLine");
+  const startupOptions: [string] =
+    (addDefaults ? bazelConfigCmdLine.startupOptions : []);
+  const commandArgs: [string] =
+    (addDefaults ? bazelConfigCmdLine.commandArgs : []);
+
+  const args = startupOptions
+    .concat([command as string])
+    .concat(commandArgs)
     .concat(options.targets)
     .concat(options.options)
     .map(quotedOption);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -354,7 +354,7 @@ async function bazelClean() {
     options: [],
     targets: [],
     workspaceInfo: BazelWorkspaceInfo.fromWorkspaceFolder(workspaceFolder),
-  });
+  }, false);
   vscode.tasks.executeTask(task);
 }
 
@@ -406,7 +406,7 @@ function onTaskProcessEnd(event: vscode.TaskProcessEndEvent) {
       const timeInSeconds = measurePerformance(bazelTaskInfo.startTime);
       vscode.window.showInformationMessage(
         `Bazel ${
-          bazelTaskInfo.command
+        bazelTaskInfo.command
         } completed successfully in ${timeInSeconds} seconds.`,
       );
     }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -354,7 +354,7 @@ async function bazelClean() {
     options: [],
     targets: [],
     workspaceInfo: BazelWorkspaceInfo.fromWorkspaceFolder(workspaceFolder),
-  }, false);
+  });
   vscode.tasks.executeTask(task);
 }
 
@@ -406,7 +406,7 @@ function onTaskProcessEnd(event: vscode.TaskProcessEndEvent) {
       const timeInSeconds = measurePerformance(bazelTaskInfo.startTime);
       vscode.window.showInformationMessage(
         `Bazel ${
-        bazelTaskInfo.command
+          bazelTaskInfo.command
         } completed successfully in ${timeInSeconds} seconds.`,
       );
     }


### PR DESCRIPTION
They follow the normal vscode support, they could be per directory, workspace,
or user.

Fixes #134