### PR TITLE
Use doublequotes to support Windows.

### DIFF
--- a/src/bazel/bazellib/bazel_utils.ts
+++ b/src/bazel/bazellib/bazel_utils.ts
@@ -45,7 +45,7 @@ export async function getTargetsForBuildFile(
   const queryResult = await new BazelQuery(
     bazelExecutable,
     workspace,
-    `'kind(rule, ${pkg}:all)'`,
+    `"kind(rule, ${pkg}:all)"`,
     [],
   ).queryTargets();
 


### PR DESCRIPTION
Looks like all the queries in extension.ts already was using double quotes
for this, and only this one was trying to use single quotes. It appears the
single quotes relied on the shell to handle them to make things work.

Fixes #153