### PR TITLE
Include node_modules.

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,5 @@
 .vscode-test/**
 .vscode/**
-node_modules/**
 out/test/**
 scripts/**
 src/**


### PR DESCRIPTION
Since the extension isn't a webpack, I think this is still needed.