### PR TITLE
Support startup options in all queries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
                     },
                     "uniqueItems": true,
                     "default": [],
-                    "markdownDescription": "A list of [Bazel startup options](https://docs.bazel.build/versions/master/command-line-reference.html#startup-options) to use when building, running tests, or cleaning. One option per entry, no shell escaping is needed."
+                    "markdownDescription": "A list of [Bazel startup options](https://docs.bazel.build/versions/master/command-line-reference.html#startup-options) to use when building, running tests, running queries, or cleaning. One option per entry, no shell escaping is needed."
                 },
                 "bazel.commandLine.commandArgs": {
                     "type": "array",

--- a/src/bazel/bazel_command.ts
+++ b/src/bazel/bazel_command.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as vscode from "vscode";
 import { BazelWorkspaceInfo } from "./bazel_workspace_info";
 
 /**
@@ -67,7 +68,11 @@ export abstract class BazelCommand {
 
   /** The args used to execute the for the command. */
   protected execArgs(additionalOptions: string[] = []) {
-    const result = [this.bazelCommand()]
+    const bazelConfigCmdLine = vscode.workspace.getConfiguration("bazel.commandLine");
+    const startupOptions: [string] = bazelConfigCmdLine.startupOptions;
+
+    const result = startupOptions
+      .concat([this.bazelCommand()])
       .concat(this.options)
       .concat(additionalOptions);
 


### PR DESCRIPTION
Developers might need bazel options enabled to get the targets they want
defined, so also support startup options in the queries.