### PR TITLE
Make queries use --output_base.

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
                     "default": false,
                     "description": "Whether to automatically apply lint fixes from buildifier when formatting a Bazel file."
                 },
+                "bazel.queriesShareServer": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use same Bazel server for queries and builds."
+                },
                 "bazel.pathsToIgnore": {
                     "type": "array",
                     "items": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
                 "bazel.queriesShareServer": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Use same Bazel server for queries and builds."
+                    "description": "Use the same Bazel server for queries and builds. By default, vscode-bazel uses a separate server for queries so that they can be executed in parallel with builds. You can enable this setting if running multiple Bazel servers has a negative performance impact on your system, but you may experience degraded performance in Visual Studio Code for operations that require queries."
                 },
                 "bazel.pathsToIgnore": {
                     "type": "array",

--- a/src/bazel/bazel_command.ts
+++ b/src/bazel/bazel_command.ts
@@ -58,7 +58,7 @@ export abstract class BazelCommand {
     readonly bazelExecutable: string,
     readonly workingDirectory: string,
     readonly options: string[] = [],
-  ) {}
+  ) { }
 
   /**
    * Overridden by subclasses to provide the Bazel command that should be
@@ -67,11 +67,15 @@ export abstract class BazelCommand {
   protected abstract bazelCommand(): string;
 
   /** The args used to execute the for the command. */
-  protected execArgs(additionalOptions: string[] = []) {
+  protected execArgs(
+    additionalOptions: string[] = [],
+    additionalStartupOptions: string[] = [],
+  ) {
     const bazelConfigCmdLine = vscode.workspace.getConfiguration("bazel.commandLine");
     const startupOptions: [string] = bazelConfigCmdLine.startupOptions;
 
     const result = startupOptions
+      .concat(additionalStartupOptions)
       .concat([this.bazelCommand()])
       .concat(this.options)
       .concat(additionalOptions);


### PR DESCRIPTION
By default, move all queries over to a custom --output_base. This keep the
bazel lock from interfering with user done builds/ibazel/etc.

Helps with #75.