### PR TITLE
Enabled/disable command and TreeView based on having a bazel workspace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     ],
     "activationEvents": [
         "onLanguage:starlark",
-        "onView:bazelWorkspace"
+        "onView:bazelWorkspace",
+        "onCommand:bazel.refreshBazelBuildTargets"
     ],
     "main": "./out/src/extension/extension",
     "contributes": {
@@ -221,6 +222,38 @@
                 {
                     "command": "bazel.copyTargetToClipboard",
                     "when": "false"
+                },
+                {
+                    "command": "bazel.buildTarget",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
+                    "command": "bazel.buildTargetWithDebugging",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
+                    "command": "bazel.buildAll",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
+                    "command": "bazel.buildAllRecursive",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
+                    "command": "bazel.testTarget",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
+                    "command": "bazel.testAll",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
+                    "command": "bazel.testAllRecursive",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
+                    "command": "bazel.clean",
+                    "when": "vscodeBazelHaveBazelWorkspace"
                 }
             ],
             "view/item/context": [
@@ -311,7 +344,8 @@
             "explorer": [
                 {
                     "id": "bazelWorkspace",
-                    "name": "Bazel Build Targets"
+                    "name": "Bazel Build Targets",
+                    "when": "vscodeBazelHaveBazelWorkspace"
                 }
             ]
         }


### PR DESCRIPTION
The "refresh" command is left enabled in the palette to support a developer
adding files such that it becomes a Bazel workspace or for them to add
another folder to an existing code-workspace and that new folder containing
a Bazel workspace.

Fixes #144