### PR TITLE
Allow pathsToIgnore to be set on the workspace level.

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
                         "type": "string"
                     },
                     "uniqueItems": true,
-                    "scope": "application",
                     "default": [],
                     "description": "A list of Regexs that when matched cause paths not to be checked for being in a WORKSPACE. This impacts operations that require a workspace, like queries, but syntax highlighting and buildifier work regardless."
                 },


### PR DESCRIPTION
While it likely makes more sense to users to set this on the app level so can
apply at scale, I've recently had a few use cases where it would be useful to
stick "." in here to on a project level just to disable this extension for this
one case and that's far easier than making a regex for the specific one off
path.