### PR TITLE
syntaxes: synchronize fileTypes with those indicated in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,6 @@
                     ".bzl",
                     ".sky",
                     ".star",
-                    ".build_defs"
                 ],
                 "filenames": [
                     "BUILD",

--- a/package.json
+++ b/package.json
@@ -210,7 +210,8 @@
                     ".WORKSPACE",
                     ".bzl",
                     ".sky",
-                    ".star"
+                    ".star",
+                    ".build_defs"
                 ],
                 "filenames": [
                     "BUILD",

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
                     ".WORKSPACE",
                     ".bzl",
                     ".sky",
-                    ".star",
+                    ".star"
                 ],
                 "filenames": [
                     "BUILD",

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -9,7 +9,7 @@
         "star",
         "BUILD.bazel",
         "WORKSPACE",
-        "WORKSPACE.bazel",
+        "WORKSPACE.bazel"
     ],
     "patterns": [
         {

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -2,10 +2,15 @@
     "name": "Starlark",
     "scopeName": "source.starlark",
     "fileTypes": [
+        "BUILD",
+        "WORKSPACE",
         "bzl",
+        "sky",
         "star",
         "build_defs",
-        "BUILD"
+        "BUILD.bazel",
+        "WORKSPACE",
+        "WORKSPACE.bazel",
     ],
     "patterns": [
         {

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -7,7 +7,6 @@
         "bzl",
         "sky",
         "star",
-        "build_defs",
         "BUILD.bazel",
         "WORKSPACE",
         "WORKSPACE.bazel",

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -3,6 +3,9 @@
     "scopeName": "source.starlark",
     "fileTypes": [
         "bzl"
+        "star"
+        "build_defs"
+        "BUILD"
     ],
     "patterns": [
         {

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -2,9 +2,9 @@
     "name": "Starlark",
     "scopeName": "source.starlark",
     "fileTypes": [
-        "bzl"
-        "star"
-        "build_defs"
+        "bzl",
+        "star",
+        "build_defs",
         "BUILD"
     ],
     "patterns": [


### PR DESCRIPTION
This synchronizes the fileTypes in the syntax (which is more correct and helps those trying to use the syntax outside of VS Code) with those indicated in package.json

Note: In the case of `BUILD`, for example, which is not an extension, modern interpreters for tmLanguage support non-extension filenames here per https://forum.sublimetext.com/t/tmlanguage-and-filename-patterns/383