### PR TITLE
Updated .vscode/settings.json format settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,7 @@
         "editor.rulers": [80]
     },
     "prettier.tslintIntegration": true,
+    "prettier.trailingComma": "all",
     "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
 }


### PR DESCRIPTION
I was looking to contribute and my default settings for vscode were using a different formatter than the one it looks like this project requires. I also noticed that the formatting in the repository is using trailing commas so I enabled that setting with on prettier.