### PR TITLE
sort targets in code lens

### DIFF
--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -47,7 +47,7 @@ export async function getTargetsForBuildFile(
     workspace,
     `kind(rule, ${pkg}:all)`,
     [],
-  ).queryTargets();
+  ).queryTargets([], /* sortByRuleName: */ true);
 
   return queryResult;
 }


### PR DESCRIPTION
On a build rule that generates more than one targets, the targets appears randomly in order on that build rule. It causes me clicking on the wrong target when the order is changed. Sorting it should fix the issue.