### PR TITLE
upgrade path-parse explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "vscode-bazel",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.4.1",
+            "name": "vscode-bazel",
+            "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "protobufjs": "^6.8.0",
@@ -435,9 +436,9 @@
             }
         },
         "node_modules/path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
         "node_modules/protobufjs": {


### PR DESCRIPTION
Any other changes to packages.json adds a downgrade (for some reason) to
path-parse 1.0.6 to the packages-lock.json. That's not ideal and, on top
of that, 1.0.6 has a vulnerability in it.
https://github.com/advisories/GHSA-hj48-42vr-x3v9
    
To prevent that from happening, we upgrade to 1.0.7 explicitly in the
lockfile.
