### PR TITLE
NOT FOR SUBMISSION - demo .vscode changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,4 +12,7 @@
     "prettier.trailingComma": "all",
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[shellscript]": {
+        "editor.defaultFormatter": "foxundermoon.shell-format"
+    },
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,16 +8,10 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
 
     // we want to run npm
     "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
 
     // we run the custom script "compile" as defined in package.json
     "args": ["run", "compile", "--loglevel", "silent"],
@@ -26,5 +20,24 @@
     "isBackground": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "problemMatcher": "$tsc-watch",
+    "tasks": [
+        {
+            "label": "npm",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile",
+                "--loglevel",
+                "silent"
+            ],
+            "isBackground": true,
+            "problemMatcher": "$tsc-watch",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        }
+    ]
 }


### PR DESCRIPTION
This includes two commits that demonstrate the changes I talked about in #255 

The first is the (entirely automated by vscode, apparently) changes to `.vscode/tasks.json` and the second is what I had to do to get Prettifier to not be mad at me while editing `scripts/build.sh`

- automated upgrade of tasks.json by vscode
- and the shell formatter change
