### PR TITLE
return `default` for .sky files in getBuildifierFileType

### DIFF
--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -21,7 +21,7 @@ import { IBuildifierResult, IBuildifierWarning } from "./buildifier_result";
 export type BuildifierLintMode = "fix" | "warn";
 
 /** The type of file that buildifier should interpret standard input as. */
-export type BuildifierFileType = "build" | "bzl" | "workspace";
+export type BuildifierFileType = "build" | "bzl" | "workspace" | "default";
 
 /**
  * Invokes buildifier in format mode.
@@ -131,7 +131,7 @@ export function getBuildifierFileType(fsPath: string): BuildifierFileType {
   if (parsedPath.ext === ".oss") {
     parsedPath = path.parse(parsedPath.name);
   }
-  if (parsedPath.ext === ".bzl" || parsedPath.ext === ".sky") {
+  if (parsedPath.ext === ".bzl") {
     return "bzl";
   }
   if (
@@ -148,7 +148,7 @@ export function getBuildifierFileType(fsPath: string): BuildifierFileType {
   ) {
     return "workspace";
   }
-  return "bzl";
+  return "default";
 }
 
 /**

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -131,8 +131,11 @@ export function getBuildifierFileType(fsPath: string): BuildifierFileType {
   if (parsedPath.ext === ".oss") {
     parsedPath = path.parse(parsedPath.name);
   }
-  if (parsedPath.ext === ".bzl") {
-    return "bzl";
+  switch (parsedPath.ext) {
+    case ".bzl":
+      return "bzl";
+    case ".sky":
+      return "default";
   }
   if (
     parsedPath.ext === ".build" ||


### PR DESCRIPTION
## What 
I noticed that the vscode extension's outputs for copybara configuration files are different from the CLI's output.
## Why
`getBuildifierFileType` is out of sync with <https://github.com/bazelbuild/buildtools/blob/a43aed7014c840a4c20c84958f3f15df5da780f5/build/lex.go#L125-L151>

## Ref
- https://github.com/bazelbuild/buildtools/pull/560
- [getBuildifierFileType](https://github.com/bazelbuild/vscode-bazel/blob/ffd1450a4222825db11533aac5f5c7aa51ef50eb/src/buildifier/buildifier.ts#L116-L152)