### PR TITLE
Add dummy BUILD and WORKSPACE files to fix CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,10 +4,6 @@ tasks:
     shell_commands:
       # Install Node.js and NPM
       - "curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - && sudo apt -y install nodejs && sudo npm install -g npm@latest"
-      # Buildkite expects to be able to build at least one target, so we create
-      # a dummy workspace here.
-      - echo 'workspace(name = "build_bazel_vscode_bazel_dummy")' > WORKSPACE
-      - echo 'filegroup(name = "dummy")' > BUILD
       # Install node_modules and then compile and check the code for lint
       # errors.
       - npm ci
@@ -19,4 +15,4 @@ tasks:
       # Typescript 3 yet.
       # (https://github.com/azz/prettier-tslint/issues/18)
     build_targets:
-      - "//:dummy"
+      - "//:dummy_target_for_ci"

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,3 @@
+# This target only exists so that we can run some npm commands on Bazel CI (Buildkite).
+# Eventually we should fix this project so that it can be built and tested with Bazel.
+filegroup(name = "dummy_target_for_ci")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "build_bazel_vscode_bazel")


### PR DESCRIPTION
This commit fixes #269, which was caused by bazelbuild/continuous-integration#1331

Some context:

Our CI infra expects all projects to be buildable with Bazel, i.e. there must be a WORKSPACE file and at least one BUILD file.
This project did not meet this requirement, but we still wanted to have it on CI to run some npm commands. Someone came up with a workaround:
Let's create dummy WORKSPACE and BUILD files during setup ("shell_commands").
However, this stopped working because bazelbuild/continuous-integration#1331 changed the CI infra to run `bazel info` before executing the shell commands, which then failed because there was no Bazel workspace yet.

Eventually we should make this project buildable and testable with Bazel.