### PR TITLE
Add bazel.getTargetOutput command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "activationEvents": [
         "onLanguage:starlark",
         "onView:bazelWorkspace",
-        "onCommand:bazel.refreshBazelBuildTargets"
+        "onCommand:bazel.refreshBazelBuildTargets",
+        "onCommand:bazel.getTargetOutput"
     ],
     "main": "./out/src/extension/extension",
     "contributes": {
@@ -82,6 +83,11 @@
                 "category": "Bazel",
                 "command": "bazel.copyTargetToClipboard",
                 "title": "Copy Label to Clipboard"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.getTargetOutput",
+                "title": "Get output path for the given target"
             }
         ],
         "configuration": {

--- a/src/bazel/bazel_cquery.ts
+++ b/src/bazel/bazel_cquery.ts
@@ -14,7 +14,18 @@
 
 import { BazelQuery } from "./bazel_query";
 
+/** Provides a promise-based API around a Bazel cquery. */
 export class BazelCQuery extends BazelQuery {
+  /**
+   * Constructs and executes a cquery command that obtains the output files of
+   * a given target.
+   * 
+   * @param target The target to query.
+   * @param options Additional command line options that should be
+   *     passed just to this specific invocation of the query.
+   * @returns The files that are outputs of the given target, as paths relative
+   *     to the execution root.
+   */
   public async queryOutputs(
     target: string,
     options: string[] = [],

--- a/src/bazel/bazel_cquery.ts
+++ b/src/bazel/bazel_cquery.ts
@@ -19,7 +19,7 @@ export class BazelCQuery extends BazelQuery {
   /**
    * Constructs and executes a cquery command that obtains the output files of
    * a given target.
-   * 
+   *
    * @param target The target to query.
    * @param options Additional command line options that should be
    *     passed just to this specific invocation of the query.

--- a/src/bazel/bazel_cquery.ts
+++ b/src/bazel/bazel_cquery.ts
@@ -1,0 +1,41 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { BazelQuery } from "./bazel_query";
+
+export class BazelCQuery extends BazelQuery {
+  public async queryOutputs(
+    target: string,
+    options: string[] = [],
+  ): Promise<string[]> {
+    return (
+      await this.run([
+        target,
+        ...options,
+        "--output=starlark",
+        "--starlark:expr",
+        '"\\n".join([f.path for f in target.files.to_list()])',
+      ])
+    )
+      .toString("utf-8")
+      .trim()
+      .replace(/\r\n|\r/g, "\n")
+      .split("\n")
+      .sort();
+  }
+
+  protected bazelCommand(): string {
+    return "cquery";
+  }
+}

--- a/src/bazel/bazel_info.ts
+++ b/src/bazel/bazel_info.ts
@@ -20,7 +20,7 @@ import { BazelCommand } from "./bazel_command";
 export class BazelInfo extends BazelCommand {
   /**
    * Runs `bazel info <key>` and returns the output.
-   * 
+   *
    * @param key The info key to query.
    * @returns The output of `bazel info <key>`.
    */

--- a/src/bazel/bazel_info.ts
+++ b/src/bazel/bazel_info.ts
@@ -1,0 +1,40 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as child_process from "child_process";
+
+import { BazelCommand } from "./bazel_command";
+
+export class BazelInfo extends BazelCommand {
+  public async run(key: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      child_process.execFile(
+        this.bazelExecutable,
+        this.execArgs([key]),
+        { cwd: this.workingDirectory },
+        (error: Error, stdout: string) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(stdout.trim());
+          }
+        },
+      );
+    });
+  }
+
+  protected bazelCommand(): string {
+    return "info";
+  }
+}

--- a/src/bazel/bazel_info.ts
+++ b/src/bazel/bazel_info.ts
@@ -16,7 +16,14 @@ import * as child_process from "child_process";
 
 import { BazelCommand } from "./bazel_command";
 
+/** Provides a promise-based API around the `bazel info` command. */
 export class BazelInfo extends BazelCommand {
+  /**
+   * Runs `bazel info <key>` and returns the output.
+   * 
+   * @param key The info key to query.
+   * @returns The output of `bazel info <key>`.
+   */
   public async run(key: string): Promise<string> {
     return new Promise((resolve, reject) => {
       child_process.execFile(

--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -29,8 +29,13 @@ export class BazelQuery extends BazelCommand {
    * that match.
    *
    * @param query The query to execute.
-   * @param additionalOptions Additional command line options that should be
+   * @param options
+   * @param options.additionalOptions Additional command line options that should be
    *     passed just to this specific invocation of the query.
+   * @param options.sortByRuleName If `true`, the results from the query will
+   *     be sorted by their name.
+   * @param options.ignoresErrors `true` if errors from executing the query
+   *     should be ignored.
    * @returns A {@link QueryResult} object that contains structured information
    *     about the query results.
    */
@@ -72,8 +77,7 @@ export class BazelQuery extends BazelCommand {
    * Runs the query and returns an array of package paths containing the targets
    * that match.
    *
-   * @param additionalOptions Additional command line options that should be
-   *     passed just to this specific invocation of the query.
+   * @param query The query to execute.
    * @returns An sorted array of package paths containing the targets that
    *     match.
    */
@@ -96,8 +100,10 @@ export class BazelQuery extends BazelCommand {
    * Executes the command and returns a promise for the binary contents of
    * standard output.
    *
-   * @param additionalOptions Additional command line options that apply only to
-   *     this particular invocation of the command.
+   * @param query The query to execute.
+   * @param options
+   * @param options.ignoresErrors `true` if errors from executing the query
+   *     should be ignored.
    * @returns A promise that is resolved with the contents of the process's
    *     standard output, or rejected if the command fails.
    */

--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -30,8 +30,8 @@ export class BazelQuery extends BazelCommand {
    *
    * @param query The query to execute.
    * @param options
-   * @param options.additionalOptions Additional command line options that should be
-   *     passed just to this specific invocation of the query.
+   * @param options.additionalOptions Additional command line options that
+   *     should be passed just to this specific invocation of the query.
    * @param options.sortByRuleName If `true`, the results from the query will
    *     be sorted by their name.
    * @param options.ignoresErrors `true` if errors from executing the query

--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -77,9 +77,7 @@ async function queryWorkspaceQuickPickTargets(
   const queryResult = await new BazelQuery(
     getDefaultBazelExecutablePath(),
     workspaceInfo.workspaceFolder.uri.fsPath,
-    query,
-    [],
-  ).queryTargets();
+  ).queryTargets(query);
   // Sort the labels so the QuickPick is ordered.
   const labels = queryResult.target.map((target) => target.rule.name);
   labels.sort();
@@ -101,9 +99,7 @@ async function queryWorkspaceQuickPickPackages(
   const packagePaths = await new BazelQuery(
     getDefaultBazelExecutablePath(),
     workspaceInfo.workspaceFolder.uri.fsPath,
-    "...:*",
-    [],
-  ).queryPackages();
+  ).queryPackages("...:*");
   const result: BazelTargetQuickPick[] = [];
   for (const target of packagePaths) {
     result.push(new BazelTargetQuickPick("//" + target, workspaceInfo));

--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -47,9 +47,7 @@ export async function getTargetsForBuildFile(
   const queryResult = await new BazelQuery(
     bazelExecutable,
     workspace,
-    `kind(rule, ${pkg}:all)`,
-    [],
-  ).queryTargets([], /* sortByRuleName: */ true);
+  ).queryTargets(`kind(rule, ${pkg}:all)`, { sortByRuleName: true });
 
   return queryResult;
 }

--- a/src/bazel/bazel_workspace_info.ts
+++ b/src/bazel/bazel_workspace_info.ts
@@ -67,6 +67,29 @@ export class BazelWorkspaceInfo {
   }
 
   /**
+   * Returns a selected Bazel workspace from among the open VS workspace
+   * folders. If there is only a single workspace folder open, it will be used.
+   * If there are multiple workspace folders open, a quick-pick window will be
+   * opened asking the user to choose one.
+   */
+  public static async fromWorkspaceFolders(): Promise<
+    BazelWorkspaceInfo | undefined
+  > {
+    switch (vscode.workspace.workspaceFolders?.length) {
+      case undefined:
+      case 0:
+        return undefined;
+      case 1:
+        return this.fromWorkspaceFolder(vscode.workspace.workspaceFolders[0]);
+      default:
+        const workspaceFolder = await vscode.window.showWorkspaceFolderPick();
+        return workspaceFolder
+          ? this.fromWorkspaceFolder(workspaceFolder)
+          : undefined;
+    }
+  }
+
+  /**
    * Initializes a new workspace info object.
    *
    * @param bazelWorkspacePath The closest directory to a document that contains

--- a/src/definition/bazel_goto_definition_provider.ts
+++ b/src/definition/bazel_goto_definition_provider.ts
@@ -54,9 +54,7 @@ export class BazelGotoDefinitionProvider implements DefinitionProvider {
     const queryResult = await new BazelQuery(
       getDefaultBazelExecutablePath(),
       Utils.dirname(document.uri).fsPath,
-      `kind(rule, "${targetName}")`,
-      [],
-    ).queryTargets();
+    ).queryTargets(`kind(rule, "${targetName}")`);
 
     if (!queryResult.target.length) {
       return null;

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -56,10 +56,10 @@ export class BazelPackageTreeItem
     const queryResult = await new BazelQuery(
       getDefaultBazelExecutablePath(),
       this.workspaceInfo.bazelWorkspacePath,
-      `//${this.packagePath}:all`,
-      [],
-      true,
-    ).queryTargets([], /* sortByRuleName: */ true);
+    ).queryTargets(`//${this.packagePath}:all`, {
+      ignoresErrors: true,
+      sortByRuleName: true,
+    });
     const targets = queryResult.target.map((target: blaze_query.Target) => {
       return new BazelTargetTreeItem(this.workspaceInfo, target);
     });

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -160,9 +160,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     const packagePaths = await new BazelQuery(
       getDefaultBazelExecutablePath(),
       workspacePath,
-      "...:*",
-      [],
-    ).queryPackages();
+    ).queryPackages("...:*");
     const topLevelItems: BazelPackageTreeItem[] = [];
     this.buildPackageTree(
       packagePaths,
@@ -177,10 +175,10 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     const queryResult = await new BazelQuery(
       getDefaultBazelExecutablePath(),
       workspacePath,
-      `:all`,
-      [],
-      true,
-    ).queryTargets([], /* sortByRuleName: */ true);
+    ).queryTargets(`:all`, {
+      ignoresErrors: true,
+      sortByRuleName: true,
+    });
     const targets = queryResult.target.map((target: blaze_query.Target) => {
       return new BazelTargetTreeItem(this.workspaceInfo, target);
     });


### PR DESCRIPTION
This command can be used in launch configurations to obtain the path to an executable built by Bazel. For example, you can set the "program" attribute of a launch configuration to an input variable:

    "program": "${input:binaryOutputLocation}"

Then define a command input variable:

    "inputs" [
        {
            "id": "binaryOutputLocation",
            "type": "command",
            "command": "bazel.getOutputTarget",
            "args": ["//my/binary:target"],
        }
    ]

Addresses https://github.com/bazelbuild/vscode-bazel/issues/273 and could form the basis of https://github.com/bazelbuild/vscode-bazel/issues/217, https://github.com/bazelbuild/vscode-bazel/issues/207, and https://github.com/bazelbuild/vscode-bazel/issues/115.