### PR TITLE
fixes minor transpositiion in example for new bazel.getTargetOutput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 
   Then define a command input variable:
 
-      "inputs" [
+      "inputs": [
           {
               "id": "binaryOutputLocation",
               "type": "command",
-              "command": "bazel.getOutputTarget",
+              "command": "bazel.getTargetOutput",
               "args": ["//my/binary:target"],
           }
       ]

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -411,11 +411,11 @@ async function bazelCopyTargetToClipboard(
  *
  * Then define a command input variable:
  *
- *     "inputs" [
+ *     "inputs": [
  *         {
  *             "id": "binaryOutputLocation",
  *             "type": "command",
- *             "command": "bazel.getOutputTarget",
+ *             "command": "bazel.getTargetOutput",
  *             "args": ["//my/binary:target"],
  *         }
  *     ]


### PR DESCRIPTION
There is a minor transposition that needs to be fixed in the example and a missing : It should be:

"inputs": [
          {
              "id": "binaryOutputLocation",
              "type": "command",
              "command": "bazel.getTargetOutput",
              "args": ["//my/binary:target"],
          }
      ]
bazel.getOutputTarget -> getTargetOutput and inputs needs a :