### PR TITLE
make output_base directory configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
                     "default": false,
                     "description": "Use the same Bazel server for queries and builds. By default, vscode-bazel uses a separate server for queries so that they can be executed in parallel with builds. You can enable this setting if running multiple Bazel servers has a negative performance impact on your system, but you may experience degraded performance in Visual Studio Code for operations that require queries."
                 },
+                "bazel.queryOutputBase": {
+                    "type": "string",
+                    "default": null,
+                    "description": "If queriesShareServer is false, this sets the directory in which bazel will create its output_base directory. Defaults to $TMPDIR."
+                },
                 "bazel.enableCodeLens": {
                     "type": "boolean",
                     "default": false,

--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -128,9 +128,10 @@ export class BazelQuery extends BazelCommand {
       // the server is shared for all the queries.
       const ws = getBazelWorkspaceFolder(this.workingDirectory);
       const hash = crypto.createHash("md5").update(ws).digest("hex");
-      const outputBase = path.join(os.tmpdir(), hash);
+      const queryOutputBaseConfigValue = bazelConfig.get<string>("queryOutputBase");
+      const queryOutputBase = path.join(queryOutputBaseConfigValue ?? os.tmpdir(), hash);
       additionalStartupOptions = additionalStartupOptions.concat([
-        `--output_base=${outputBase}`,
+        `--output_base=${queryOutputBase}`,
       ]);
     }
     return new Promise((resolve, reject) => {

--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -128,8 +128,10 @@ export class BazelQuery extends BazelCommand {
       // the server is shared for all the queries.
       const ws = getBazelWorkspaceFolder(this.workingDirectory);
       const hash = crypto.createHash("md5").update(ws).digest("hex");
-      const queryOutputBaseConfigValue = bazelConfig.get<string>("queryOutputBase");
-      const queryOutputBase = path.join(queryOutputBaseConfigValue ?? os.tmpdir(), hash);
+      const queryOutputBaseConfigValue =
+          bazelConfig.get<string>("queryOutputBase");
+      const queryOutputBase =
+          path.join(queryOutputBaseConfigValue ?? os.tmpdir(), hash);
       additionalStartupOptions = additionalStartupOptions.concat([
         `--output_base=${queryOutputBase}`,
       ]);


### PR DESCRIPTION
Adds an outputBase string configuration that changes where output_base is placed. This is convenient for when someone wants bazel using something other than TMPDIR. This is useful if you use a ramdisk for faster builds, or if your TMPDIR has space or security constraints.