### PR TITLE
Expand matching files to *.bazel

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,12 +214,12 @@
                     "Bazel"
                 ],
                 "extensions": [
-                    ".bazel",
                     ".BUILD",
+                    ".WORKSPACE",
+                    ".bazel",
                     ".bzl",
                     ".sky",
-                    ".star",
-                    ".WORKSPACE"
+                    ".star"
                 ],
                 "filenames": [
                     "BUILD",

--- a/package.json
+++ b/package.json
@@ -214,17 +214,16 @@
                     "Bazel"
                 ],
                 "extensions": [
+                    ".bazel",
                     ".BUILD",
-                    ".WORKSPACE",
                     ".bzl",
                     ".sky",
-                    ".star"
+                    ".star",
+                    ".WORKSPACE"
                 ],
                 "filenames": [
                     "BUILD",
-                    "BUILD.bazel",
-                    "WORKSPACE",
-                    "WORKSPACE.bazel"
+                    "WORKSPACE"
                 ],
                 "configuration": "./syntaxes/starlark.configuration.json"
             }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -108,9 +108,8 @@ export function activate(context: vscode.ExtensionContext) {
       [
         { language: "starlark" },
         { pattern: "**/BUILD" },
-        { pattern: "**/BUILD.bazel" },
+        { pattern: "**/*.bazel" },
         { pattern: "**/WORKSPACE" },
-        { pattern: "**/WORKSPACE.bazel" },
         { pattern: "**/*.BUILD" },
         { pattern: "**/*.bzl" },
         { pattern: "**/*.sky" },

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -2,14 +2,12 @@
     "name": "Starlark",
     "scopeName": "source.starlark",
     "fileTypes": [
+        "bazel",
         "BUILD",
-        "WORKSPACE",
         "bzl",
         "sky",
         "star",
-        "BUILD.bazel",
-        "WORKSPACE",
-        "WORKSPACE.bazel"
+        "WORKSPACE"
     ],
     "patterns": [
         {
@@ -920,7 +918,7 @@
                 }
             }
         },
-       "discouraged-semicolon": {
+        "discouraged-semicolon": {
             "patterns": [
                 {
                     "name": "invalid.deprecated.semicolon.starlark",

--- a/syntaxes/starlark.tmLanguage.json
+++ b/syntaxes/starlark.tmLanguage.json
@@ -2,12 +2,12 @@
     "name": "Starlark",
     "scopeName": "source.starlark",
     "fileTypes": [
-        "bazel",
         "BUILD",
+        "WORKSPACE",
+        "bazel",
         "bzl",
         "sky",
-        "star",
-        "WORKSPACE"
+        "star"
     ],
     "patterns": [
         {


### PR DESCRIPTION
With the addition of `MODULE.bazel` to the mix, it seems to make sense to match all files with this extension.