### PR TITLE
Make executable and buildifierExecutable settings `machine-overridable`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,13 +98,13 @@
                     "type": "string",
                     "default": "",
                     "description": "The name of the Bazel executable. This may be an absolute path, or a simple name that will be searched for on the system path. If empty, \"bazel\" on the system path will be used.",
-                    "scope": "machine"
+                    "scope": "machine-overridable"
                 },
                 "bazel.buildifierExecutable": {
                     "type": "string",
                     "default": "",
                     "markdownDescription": "The name of the Buildifier executable. This may be an absolute path, or a simple name that will be searched for on the system path. If empty, \"buildifier\" on the system path will be used.\n\nBuildifier can be downloaded from https://github.com/bazelbuild/buildtools/releases.",
-                    "scope": "machine"
+                    "scope": "machine-overridable"
                 },
                 "bazel.buildifierFixOnFormat": {
                     "type": "boolean",


### PR DESCRIPTION
> `machine-overridable` - Machine specific settings that can be overridden by workspace or folder settings.
- https://code.visualstudio.com/api/references/contribution-points

Organizations may install these binaries to a known path which can be specified in shared workspace settings.

Fixes https://github.com/bazelbuild/vscode-bazel/issues/236.