### PR TITLE
Add bazel.info.* commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
         "onLanguage:starlark",
         "onView:bazelWorkspace",
         "onCommand:bazel.refreshBazelBuildTargets",
-        "onCommand:bazel.getTargetOutput"
+        "onCommand:bazel.getTargetOutput",
+        "onCommand:bazel.info.bazel-bin",
+        "onCommand:bazel.info.bazel-genfiles",
+        "onCommand:bazel.info.bazel-testlogs",
+        "onCommand:bazel.info.execution_root",
+        "onCommand:bazel.info.output_base",
+        "onCommand:bazel.info.output_path"
     ],
     "main": "./out/src/extension/extension",
     "contributes": {
@@ -88,6 +94,36 @@
                 "category": "Bazel",
                 "command": "bazel.getTargetOutput",
                 "title": "Get output path for the given target"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.info.bazel-bin",
+                "title": "Get bazel-bin value"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.info.bazel-genfiles",
+                "title": "Get bazel-genfiles value"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.info.bazel-testlogs",
+                "title": "Get bazel-testlogs value"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.info.execution_root",
+                "title": "Get Bazel execution_root value"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.info.output_base",
+                "title": "Get Bazel output_base value"
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.info.output_path",
+                "title": "Get Bazel output_path value"
             }
         ],
         "configuration": {


### PR DESCRIPTION
I proposed these originally in https://github.com/bazelbuild/vscode-bazel/issues/273 as an initial idea for what became https://github.com/bazelbuild/vscode-bazel/pull/275. But I have encountered another use case that makes me think they are generally useful:

When [debugging on macOS](https://github.com/bazelbuild/bazel/issues/6327#issuecomment-982965782), lldb needs to be configured with the command `platform settings -w $execution_root`, where `$execution_root` is what's returned by `bazel info execution_root`. With `bazel.info.*` commands, you can create a launch configuration that contains:

```
      "initCommands": [
        "platform settings -w ${command:bazel.info.execution_root}",
      ]
```