### PR TITLE
Add a new command to run targets without arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
             },
             {
                 "category": "Bazel",
+                "command": "bazel.runTarget",
+                "title": "Run Target"
+            },
+            {
+                "category": "Bazel",
                 "command": "bazel.buildAllRecursive",
                 "title": "Build Package Recursively"
             },
@@ -297,6 +302,10 @@
                     "when": "vscodeBazelHaveBazelWorkspace"
                 },
                 {
+                    "command": "bazel.runTarget",
+                    "when": "vscodeBazelHaveBazelWorkspace"
+                },
+                {
                     "command": "bazel.testTarget",
                     "when": "vscodeBazelHaveBazelWorkspace"
                 },
@@ -342,6 +351,11 @@
                 {
                     "command": "bazel.buildAllRecursive",
                     "when": "view == bazelWorkspace && viewItem == package",
+                    "group": "build"
+                },
+                {
+                    "command": "bazel.runTarget",
+                    "when": "view == bazelWorkspace && viewItem == rule",
                     "group": "build"
                 },
                 {

--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -32,14 +32,16 @@ function quotedOption(option: string): vscode.ShellQuotedString {
  * @param options Describes the options used to launch Bazel.
  */
 export function createBazelTask(
-  command: "build" | "clean" | "test",
+  command: "build" | "clean" | "test" | "run",
   options: IBazelCommandOptions,
 ): vscode.Task {
-  const bazelConfigCmdLine = vscode.workspace.getConfiguration("bazel.commandLine");
+  const bazelConfigCmdLine =
+    vscode.workspace.getConfiguration("bazel.commandLine");
   const startupOptions = bazelConfigCmdLine.get<string[]>("startupOptions");
   const addCommandArgs = command === "build" || command === "test";
-  const commandArgs =
-    (addCommandArgs ? bazelConfigCmdLine.get<string[]>("commandArgs") : []);
+  const commandArgs = addCommandArgs
+    ? bazelConfigCmdLine.get<string[]>("commandArgs")
+    : [];
 
   const args = startupOptions
     .concat([command as string])


### PR DESCRIPTION
This implementation doesn't support to pass arguments for the `blaze run //path:taget` command, but it can be implemented in the following changes.