### PR TITLE
Fix candidate target name parsing for completion

### DIFF
--- a/src/completion-provider/bazel_completion_provider.ts
+++ b/src/completion-provider/bazel_completion_provider.ts
@@ -34,12 +34,12 @@ function getCandidateTargetFromDocumentPosition(
 ): string | undefined {
   const linePrefix = document
     .lineAt(position)
-    .text.substr(0, position.character);
-  const index = linePrefix.indexOf('"//');
+    .text.substring(0, position.character);
+  const index = linePrefix.lastIndexOf("//");
   if (index === -1) {
     return undefined;
   }
-  return linePrefix.substring(index + 1);
+  return linePrefix.substring(index);
 }
 
 function stripLastPackageOrTargetName(target: string) {


### PR DESCRIPTION
This change fixes a bug where the target completion doesn't work when the target name is not quoted (like inside `$(location)`).

Fixes #304