### PR TITLE
Update CI to Ubuntu 20 and Node 20

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,9 +1,18 @@
 ---
 tasks:
-  ubuntu1804:
+  ubuntu2004:
     shell_commands:
       # Install Node.js and NPM
-      - "curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - && sudo apt -y install nodejs && sudo npm install -g npm@latest"
+      # https://github.com/nodesource/distributions#installation-instructions
+      - |
+        sudo apt-get update
+        sudo apt-get install -y ca-certificates curl gnupg
+        sudo mkdir -p /etc/apt/keyrings
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+        NODE_MAJOR=20
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+        sudo apt-get update
+        sudo apt-get install nodejs -y
       # Install node_modules and then compile and check the code for lint
       # errors.
       - npm ci


### PR DESCRIPTION
Fixes deprecation warnings and failures in CI. See for example, https://buildkite.com/bazel/vscode-bazel-vs-bazel/builds/1993#018c22c3-eae0-4d53-96c8-7c3afe453424.