### PR TITLE
Fix query output for target location

### DIFF
--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -25,7 +25,6 @@ import { getBazelWorkspaceFolder } from "./bazel_utils";
 const protoOutputOptions = [
   "--proto:output_rule_attrs=''",
   "--noproto:rule_inputs_and_outputs",
-  "--noproto:locations",
   "--noproto:default_values",
 ];
 


### PR DESCRIPTION
I believe https://github.com/bazelbuild/vscode-bazel/pull/308 (shipped with v0.8.0) introduced a regression in the query output that results to the following bugs (see [screencast](https://github.com/bazelbuild/vscode-bazel/assets/13268391/e58b4839-34d0-4246-9d6c-ffe887ad1cd9)):
* Clicking on the targets in Bazel Build Targets no longer works.
* CodeLens feature that allows navigating to a target no longer works.
* The tooltips for build command now all shows at the top of the BUILD file instead of being inline with the targets.

Fix https://github.com/bazelbuild/vscode-bazel/issues/319
cc @iamricard