### PR TITLE
Prevent automatic MODULE.bazel file creation

### DIFF
--- a/src/bazel/bazel_command.ts
+++ b/src/bazel/bazel_command.ts
@@ -75,10 +75,21 @@ export abstract class BazelCommand {
       vscode.workspace.getConfiguration("bazel.commandLine");
     const startupOptions = bazelConfigCmdLine.get<string[]>("startupOptions");
 
+    // Options that are applied to all Bazel commands
+    const defaultOptions = [
+      // See https://bazel.build/versions/6.4.0/external/lockfile
+      // Prevent the extension from automatically creating the MODULE.bazel file
+      // on bazel v7 or newer which enable bzlmod by default
+      // Bazel can still enforce creating the MODULE.bazel automatically
+      // when users run command in local.
+      "--lockfile_mode=off"
+    ]
+
     const result = startupOptions
       .concat(additionalStartupOptions)
       .concat([this.bazelCommand()])
       .concat(this.options)
+      .concat(defaultOptions)
       .concat(additionalOptions);
 
     return result;

--- a/src/bazel/bazel_command.ts
+++ b/src/bazel/bazel_command.ts
@@ -82,8 +82,8 @@ export abstract class BazelCommand {
       // on bazel v7 or newer which enable bzlmod by default
       // Bazel can still enforce creating the MODULE.bazel automatically
       // when users run command in local.
-      "--lockfile_mode=off"
-    ]
+      "--lockfile_mode=off",
+    ];
 
     const result = startupOptions
       .concat(additionalStartupOptions)


### PR DESCRIPTION
Bazel 7 [enables bzlmod](https://bazel.build/about/roadmap#bzlmod_external_dependency_management_system) by default which results to the automatic generation of `MODULE.bazel` files when the extension runs bazel command in the background.

From a VSCode extension standpoint, it's a bad UX (IMO) to create new files unintentionally. If Bazel wants to enforce having `MODULE.bazel` files moving forward, that is already covered when users run Bazel commands locally.

In the future, we can gate this flag behind a boolean config when bzlmod is fully supported https://github.com/bazelbuild/vscode-bazel/issues/294.