### PR TITLE
Add @cameron-martin to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coeuvre @jfirebaugh
+* @coeuvre @jfirebaugh @cameron-martin


### PR DESCRIPTION
Per https://github.com/bazelbuild/vscode-bazel/issues/241#issuecomment-1900405902. Thank you for offering!

I think there's a second step that I don't have permission to do, which is to add @cameron-martin as a collaborator with write access. At least that's what GitHub is telling me:

<img width="633" alt="Screenshot 2024-01-22 at 2 56 44 PM" src="https://github.com/bazelbuild/vscode-bazel/assets/98601/39032274-5437-490e-acc3-98fb34681e6a">
