### PR TITLE
Scope eslint formatter to typescript in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,9 @@
     "[typescript]": {
         "editor.tabSize": 2,
         "editor.detectIndentation": false,
-        "editor.rulers": [80]
+        "editor.rulers": [80],
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "prettier.trailingComma": "all",
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
 }


### PR DESCRIPTION
Previously this set the formatter to eslint for all languages, but eslint only works for javascript and typescript.

Fixes #255