### PR TITLE
Disable bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+common --noenable_bzlmod


### PR DESCRIPTION
This prevents the creation of `MODULE.bazel` and `MODULE.bazel.lock` in this repository after running bazel, for example as happens automatically by this plugin after opening starlark files.