### PR TITLE
Increase vscode engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "icon": "media/bazel-logo.png",
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.85.0"
     },
     "categories": [
         "Programming Languages"


### PR DESCRIPTION
When running `vsce package`, it complains that the versions of `engines.vscode` and `@types/vscode` are incompatible. This updates `engines.vscode` to match the version of `@types/vscode`.