### PR TITLE
Activate the extension automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,11 @@
         "Programming Languages"
     ],
     "activationEvents": [
-        "onLanguage:starlark",
-        "onView:bazelWorkspace",
-        "onCommand:bazel.refreshBazelBuildTargets",
-        "onCommand:bazel.getTargetOutput",
-        "onCommand:bazel.info.bazel-bin",
-        "onCommand:bazel.info.bazel-genfiles",
-        "onCommand:bazel.info.bazel-testlogs",
-        "onCommand:bazel.info.execution_root",
-        "onCommand:bazel.info.output_base",
-        "onCommand:bazel.info.output_path"
+        "workspaceContains:**/BUILD",
+        "workspaceContains:**/WORKSPACE",
+        "workspaceContains:**/WORKSPACE.bazel",
+        "workspaceContains:**/MODULE.bazel",
+        "workspaceContains:**/REPO.bazel"
     ],
     "main": "./out/src/extension/extension",
     "contributes": {


### PR DESCRIPTION
So far, the `bazelWorkspace` view, listing the available build targets,
was only shown after running the first Bazel command, e.g., through
the command pallete. This behavior was probably unintended and is rather
cumbersome for people which want to inspect the available Bazel targets.

The chain of events which lead to this behavior are:
* The `bazelWorkspace` view is only shown when the
  `vscodeBazelHaveBazelWorkspace` context variable is set.
* This context variable is unset by default, and hence the view is
  hidden initially.
* As soon as the first Bazel command is run from the command pallete,
  the extension was activated.
* As part of activating, the extension detected that there is in fact
  a Bazel workspace and hence it set the `vscodeBazelHaveBazelWorkspace`
  context variable, unhiding the `bazelWorkspace` view.

This commit fixes the issue by activating the extension as soon as one
of Bazel's build files is found.

Furthermore, all pre-existing activation events were redundant since
VS Code 1.74 which started to automatically infer activation events
based on the contributions provided by an extension