### PR TITLE
Enable the "Restart LSP" command only if a LSP is configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
             {
                 "category": "Bazel",
                 "command": "bazel.lsp.restart",
-                "title": "Restart language server"
+                "title": "Restart language server",
+                "when": "bazel.lsp.enabled"
             }
         ],
         "configuration": {
@@ -314,39 +315,39 @@
                 },
                 {
                     "command": "bazel.buildTarget",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.buildTargetWithDebugging",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.buildAll",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.buildAllRecursive",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.runTarget",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.testTarget",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.testAll",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.testAllRecursive",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.clean",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 }
             ],
             "view/item/context": [
@@ -443,7 +444,7 @@
                 {
                     "id": "bazelWorkspace",
                     "name": "Bazel Build Targets",
-                    "when": "vscodeBazelHaveBazelWorkspace"
+                    "when": "bazel.haveWorkspace"
                 }
             ]
         }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -95,6 +95,8 @@ export async function activate(context: vscode.ExtensionContext) {
       ),
     );
   }
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  vscode.commands.executeCommand("setContext", "bazel.lsp.enabled", lspEnabled);
 
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider(

--- a/src/workspace-tree/bazel_workspace_tree_provider.ts
+++ b/src/workspace-tree/bazel_workspace_tree_provider.ts
@@ -151,7 +151,7 @@ export class BazelWorkspaceTreeProvider
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     vscode.commands.executeCommand(
       "setContext",
-      "vscodeBazelHaveBazelWorkspace",
+      "bazel.haveWorkspace",
       haveBazelWorkspace,
     );
   }


### PR DESCRIPTION
This commit hides the "Restart LSP" command from the Command Palette if the LSP is disabled. Otherwise, trying to use the "Restart LSP" command without any LSP being configured leads to a user-visible error.

As part of this, I also renamed `vscodeBazelHaveBazelWorkspace` to `bazel.haveWorkspace` such that the context variables all share a common `bazel.*` prefix.