### PR TITLE
Hide commands intended as command variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,14 @@
         "workspaceContains:**/WORKSPACE",
         "workspaceContains:**/WORKSPACE.bazel",
         "workspaceContains:**/MODULE.bazel",
-        "workspaceContains:**/REPO.bazel"
+        "workspaceContains:**/REPO.bazel",
+        "onCommand:bazel.getTargetOutput",
+        "onCommand:bazel.info.bazel-bin",
+        "onCommand:bazel.info.bazel-genfiles",
+        "onCommand:bazel.info.bazel-testlogs",
+        "onCommand:bazel.info.execution_root",
+        "onCommand:bazel.info.output_base",
+        "onCommand:bazel.info.output_path"
     ],
     "main": "./out/src/extension/extension",
     "contributes": {
@@ -89,41 +96,6 @@
                 "category": "Bazel",
                 "command": "bazel.copyTargetToClipboard",
                 "title": "Copy Label to Clipboard"
-            },
-            {
-                "category": "Bazel",
-                "command": "bazel.getTargetOutput",
-                "title": "Get output path for the given target"
-            },
-            {
-                "category": "Bazel",
-                "command": "bazel.info.bazel-bin",
-                "title": "Get bazel-bin value"
-            },
-            {
-                "category": "Bazel",
-                "command": "bazel.info.bazel-genfiles",
-                "title": "Get bazel-genfiles value"
-            },
-            {
-                "category": "Bazel",
-                "command": "bazel.info.bazel-testlogs",
-                "title": "Get bazel-testlogs value"
-            },
-            {
-                "category": "Bazel",
-                "command": "bazel.info.execution_root",
-                "title": "Get Bazel execution_root value"
-            },
-            {
-                "category": "Bazel",
-                "command": "bazel.info.output_base",
-                "title": "Get Bazel output_base value"
-            },
-            {
-                "category": "Bazel",
-                "command": "bazel.info.output_path",
-                "title": "Get Bazel output_path value"
             },
             {
                 "category": "Bazel",


### PR DESCRIPTION
The commands `bazel.info.*` and `bazel.getOutputPath` are intended to be used as command variables within `launch.json` and `task.json`. For additional context, see  #273, #275 and #291.

Those commands are not intended to be called by users directly. As such, they should not show up in the command palette. Calling them from the command picker has no user-visible effect and leaves the user with the impression that those commands would be broken.

This commit removes them from the `commands` contribution point, thereby hiding them from the command picker. To make sure that the extension is loaded as soon as some `task.json`/`launch.json` invokes any of those commands, they now need to be registered as `activationEvents`, since VS Code will no longer discover those events automatically from the `commands` contributions.