### PR TITLE
Support running buildifier through Bazel

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
                 "bazel.buildifierExecutable": {
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "The name of the Buildifier executable. This may be an absolute path, or a simple name that will be searched for on the system path. If empty, \"buildifier\" on the system path will be used.\n\nBuildifier can be downloaded from https://github.com/bazelbuild/buildtools/releases.",
+                    "markdownDescription": "The name of the Buildifier executable. This may be an absolute path, or a simple name that will be searched for on the system path. Paths starting with `@` are interpreted as Bazel targets and are run via `bazel run`. If empty, \"buildifier\" on the system path will be used.\n\nBuildifier can be downloaded from https://github.com/bazelbuild/buildtools/releases.",
                     "scope": "machine-overridable"
                 },
                 "bazel.buildifierFixOnFormat": {


### PR DESCRIPTION
Buildifier is frequently installed through Bazel as described on https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#setup-and-usage-via-bazel such that it can be run through `bazel run`.

This commit allows the `bazel.buildifierExecutable` setting to refer to a Bazel target. All paths starting with `@` are interpreted as Bazel target names and are executed through `bazel run`. Bazel targets could also start with `//` but we interpret those as normal file system paths. If someone wants to run a target in the own workspace, they can simply use, e.g., `@//:buildifier` instead of `//:buildifier`.

As a drive-by fix, I also fixed #329 since it was a one-line fix.

Fixes #185, #329

BEGIN_COMMIT_OVERRIDE
feat: Support running buildifier through Bazel (#350)

feat:  Support relative paths for bazel.buildifierExecutable (#350) 
feat: Pick up `.buildifier.json` configuration from the Bazel workspace root (#350)
END_COMMIT_OVERRIDE