### PR TITLE
Add `bazel.info.workspace` command variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "onCommand:bazel.info.bazel-testlogs",
         "onCommand:bazel.info.execution_root",
         "onCommand:bazel.info.output_base",
-        "onCommand:bazel.info.output_path"
+        "onCommand:bazel.info.output_path",
+        "onCommand:bazel.info.workspace"
     ],
     "main": "./out/src/extension/extension",
     "contributes": {

--- a/src/extension/command_variables.ts
+++ b/src/extension/command_variables.ts
@@ -134,6 +134,7 @@ export function activateCommandVariables(): vscode.Disposable[] {
       "execution_root",
       "output_base",
       "output_path",
+      "workspace",
     ].map((key) =>
       vscode.commands.registerCommand(`bazel.info.${key}`, () =>
         bazelInfo(key),


### PR DESCRIPTION
Not sure why this wasn't added initially in #291. Maybe the assumption was that the workspace root is already available through VS Code's `${workspaceFolder}`. However, that represents the place where VS Code was opened. The Bazel workspace folder might be further up in the directory tree.