### PR TITLE
Enable incremental TypeScript builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "sourceMap": true,
         "rootDir": ".",
         "alwaysStrict": true,
-        "allowJs": true
+        "allowJs": true,
+        "incremental": true,
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Cuts the time of `npm run compile` from 9 seconds to 3 seconds