### PR TITLE
feat: Introduce `pickTarget` and `pickPackage` command variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,19 @@ Bazel tasks can be configured from the `launch.json` using the following structu
       "label": "Check for flakyness",
       "type": "bazel",
       "command": "test",
-      "targets": ["//my/package:integration_test"],
+      "targets": ["${input:pickFlakyTest}"],
       "options": ["--runs_per_test=9"]
+    }
+  ],
+  "inputs": [
+    {
+      "id": "pickFlakyTest",
+      "type": "command",
+      "command": "bazel.pickTarget",
+      "args": {
+        "query": "kind('.*_test', //...:*)",
+        "placeHolder": "Which test to check for flakyness?"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This extension can use [Facebook's starlark project](https://github.com/facebook
 
 ## Bazel tasks
 
-Bazel tasks can be configured from the `launch.json` using the following structure:
+Bazel tasks can be configured from the `tasks.json` using the following structure:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
         "workspaceContains:**/WORKSPACE.bazel",
         "workspaceContains:**/MODULE.bazel",
         "workspaceContains:**/REPO.bazel",
+        "onCommand:bazel.pickPackage",
+        "onCommand:bazel.pickTarget",
         "onCommand:bazel.getTargetOutput",
         "onCommand:bazel.info.bazel-bin",
         "onCommand:bazel.info.bazel-genfiles",

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -22,5 +22,6 @@ export function assert(value: boolean): asserts value {
           "https://github.com/bazelbuild/vscode-bazel/issues",
       );
     }
+    throw new Error("Assertion violated.");
   }
 }

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,0 +1,26 @@
+import * as vscode from "vscode";
+
+let assertionFailureReported = false;
+
+/**
+ * Asserts that the given value is true.
+ */
+export function assert(value: boolean): asserts value {
+  if (!value) {
+    debugger; // eslint-disable-line no-debugger
+    if (!assertionFailureReported) {
+      // Only report one assertion failure, to avoid spamming the
+      // user with error messages.
+      assertionFailureReported = true;
+      // Log an `Error` object which will include the stack trace
+      // eslint-disable-next-line no-console
+      console.error(new Error("Assertion violated."));
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      vscode.window.showErrorMessage(
+        "Assertion violated. This is a programming error.\n" +
+          "Please file a bug at " +
+          "https://github.com/bazelbuild/vscode-bazel/issues",
+      );
+    }
+  }
+}

--- a/src/completion-provider/bazel_completion_provider.ts
+++ b/src/completion-provider/bazel_completion_provider.ts
@@ -142,7 +142,9 @@ export class BazelCompletionItemProvider
    * workspace.
    */
   public async refresh() {
-    const queryTargets = await queryQuickPickTargets("kind('.* rule', ...)");
+    const queryTargets = await queryQuickPickTargets({
+      query: "kind('.* rule', ...)",
+    });
     if (queryTargets.length !== 0) {
       this.targets = queryTargets.map((queryTarget) => {
         return queryTarget.label;

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -189,7 +189,7 @@ async function bazelBuildTarget(adapter: IBazelCommandAdapter | undefined) {
     // invoked via the command palatte. Provide quickpick build targets for
     // the user to choose from.
     const quickPick = await vscode.window.showQuickPick(
-      queryQuickPickTargets("kind('.* rule', ...)"),
+      queryQuickPickTargets({ query: "kind('.* rule', ...)" }),
       {
         canPickMany: false,
       },
@@ -221,7 +221,7 @@ async function bazelBuildTargetWithDebugging(
     // invoked via the command palatte. Provide quickpick build targets for
     // the user to choose from.
     const quickPick = await vscode.window.showQuickPick(
-      queryQuickPickTargets("kind('.* rule', ...)"),
+      queryQuickPickTargets({ query: "kind('.* rule', ...)" }),
       {
         canPickMany: false,
       },
@@ -289,7 +289,7 @@ async function buildPackage(
     // invoked via the command palatte. Provide quickpick build targets for
     // the user to choose from.
     const quickPick = await vscode.window.showQuickPick(
-      queryQuickPickPackage(),
+      queryQuickPickPackage({}),
       {
         canPickMany: false,
       },
@@ -324,7 +324,7 @@ async function bazelRunTarget(adapter: IBazelCommandAdapter | undefined) {
     // invoked via the command palatte. Provide quickpick test targets for
     // the user to choose from.
     const quickPick = await vscode.window.showQuickPick(
-      queryQuickPickTargets("kind('.* rule', ...)"),
+      queryQuickPickTargets({ query: "kind('.* rule', ...)" }),
       {
         canPickMany: false,
       },
@@ -354,7 +354,7 @@ async function bazelTestTarget(adapter: IBazelCommandAdapter | undefined) {
     // invoked via the command palatte. Provide quickpick test targets for
     // the user to choose from.
     const quickPick = await vscode.window.showQuickPick(
-      queryQuickPickTargets("kind('.*_test rule', ...)"),
+      queryQuickPickTargets({ query: "kind('.*_test rule', ...)" }),
       {
         canPickMany: false,
       },
@@ -403,7 +403,7 @@ async function testPackage(
     // invoked via the command palatte. Provide quickpick build targets for
     // the user to choose from.
     const quickPick = await vscode.window.showQuickPick(
-      queryQuickPickPackage(),
+      queryQuickPickPackage({}),
       {
         canPickMany: false,
       },


### PR DESCRIPTION
This commit introduces the `bazel.pickTarget` and `bazel.pickPackage` command variables. Those commands can be used from `tasks.json` and `launch.json` to prompt the user to select a Bazel target or package. The available choices are determined by a user-specified Bazel query.

The implementation reuses the existing quick-pick functionality from `bazel_quickpick.ts`. The `wrapQuickPick` function parses the arguments passed from the `task.json` and then forwards to the existing quickpicks.

Those utility functions were restructured as part of this commit:
1. The internal helpers `queryWorkspaceQuickPickPackages` and `queryWorkspaceQuickPickTargets` were inlined into `queryQuickPick{Packages,Targets}` as the internal helper functions got in the way of other changes, but didn't deduplicate any code as they only had one caller.
2. The `queryQuickPick{Packages,Targets}` take an object with named parameters now.
3. `queryQuickPickPackage` now also accepts a `query` parameter instead of using the `queryExpression`. Both `queryQuickPickPackages` and `queryQuickPickTargets` default to the query `//...` if no query string is provided by the caller.

Point (3) also is a user-facing change. Commands like "Build package" and "Test package" now use `//...` instead of the configured `queryExpression`. This is in sync with other commands like "Test target" which uses the hardcoded query `kind('.*_test rule', ...)`.