### PR TITLE
Add `buildifier` Json File Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,12 @@
                     "markdownDescription": "The name of the Buildifier executable. This may be an absolute path, or a simple name that will be searched for on the system path. Paths starting with `@` are interpreted as Bazel targets and are run via `bazel run`. If empty, \"buildifier\" on the system path will be used.\n\nBuildifier can be downloaded from https://github.com/bazelbuild/buildtools/releases.",
                     "scope": "machine-overridable"
                 },
+                "bazel.buildifierConfigJsonPath": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The path of the Buildifier config json file, ex: `.buildifier.json`. This may be an absolute path, or a relative path within the workspace.",
+                    "scope": "machine-overridable"
+                },
                 "bazel.buildifierFixOnFormat": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
                 "bazel.buildifierConfigJsonPath": {
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "The path of the Buildifier config json file, ex: `.buildifier.json`. This may be an absolute path, or a relative path within the workspace.",
+                    "markdownDescription": "The path of the Buildifier config json file, ex: `.buildifier.json`. This may be an absolute path, or a relative path within the workspace. If this option is unset, `buildifier` will automatically look for a `.buildifier.json` file in the workspace.",
                     "scope": "machine-overridable"
                 },
                 "bazel.buildifierFixOnFormat": {

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -175,6 +175,18 @@ export function getDefaultBuildifierExecutablePath(): string {
 }
 
 /**
+ * Gets the path to the buildifier json configuration file specified by the
+ * workspace configuration, if present.
+ *
+ * @returns The path to the buildifier json configuration file specified in the
+ * workspace configuration, or an empty string if not present.
+ */
+export function getDefaultBuildifierJsonConfigPath(): string {
+  const bazelConfig = vscode.workspace.getConfiguration("bazel");
+  return bazelConfig.get<string>("buildifierConfigJsonPath");
+}
+
+/**
  * Executes buildifier with the given file content and arguments.
  *
  * @param fileContent The BUILD or .bzl file content to process, which is sent
@@ -191,6 +203,10 @@ export function executeBuildifier(
   return new Promise((resolve, reject) => {
     // Determine the executable
     let executable = getDefaultBuildifierExecutablePath();
+    const buildifierConfigJsonPath = getDefaultBuildifierJsonConfigPath();
+    if (buildifierConfigJsonPath.length !== 0) {
+      args = ["--config", buildifierConfigJsonPath, ...args];
+    }
     // Paths starting with an `@` are referring to Bazel targets
     if (executable.startsWith("@")) {
       const targetName = executable;

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -183,7 +183,7 @@ export function getDefaultBuildifierExecutablePath(): string {
  */
 export function getDefaultBuildifierJsonConfigPath(): string {
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  return bazelConfig.get<string>("buildifierConfigJsonPath");
+  return bazelConfig.get<string>("buildifierConfigJsonPath", "");
 }
 
 /**


### PR DESCRIPTION
This PR adds the `buildifierConfigJsonPath` setting, which allows a custom path to be set to pull the json configuration file for `buildifier` (this is often `.buildifier.json`). If the `buildifierConfigJsonPath` path is set, when `buildifier` is run within this extension, the `--config <path>` CLI arguments will be passed to `buildifier`.

While it could be said that this PR is now adding support for the `.buildifier.json` file -- it's only adding support for the customization of that file path. https://github.com/bazelbuild/vscode-bazel/pull/350 actually pulled out yet another drive-by fix (of https://github.com/bazelbuild/vscode-bazel/issues/208) by adding the working directory. In that PR, `cwd: vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath` is setting the working directory for the `buildifier` execution to be the local workspace. This means any local `.buildifier.json` file will automatically get pulled in and used. This PR is allowing further customization on top of that.

The logic of this PR was tested by manually editing the js of my local extension installation with the equivalent changes (that's how I found that `cwd: ...` ended up working with a local `.buildifier.json`).