### PR TITLE
Stricter typescript configuration

### DIFF
--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -143,7 +143,7 @@ export class BazelQuery extends BazelCommand {
       ]);
     }
     return new Promise((resolve, reject) => {
-      const execOptions = {
+      const execOptions: child_process.ExecFileOptionsWithBufferEncoding = {
         cwd: this.workingDirectory,
         // A null encoding causes the callback below to receive binary data as a
         // Buffer instead of text data as strings.

--- a/src/buildifier/buildifier_format_provider.ts
+++ b/src/buildifier/buildifier_format_provider.ts
@@ -51,7 +51,7 @@ export class BuildifierFormatProvider
         ),
       ];
       return edits;
-    } catch (err) {
+    } catch (err: any) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       vscode.window.showErrorMessage(`${err}`);
     }

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -61,7 +61,7 @@ export class BazelPackageTreeItem
       ignoresErrors: true,
       sortByRuleName: true,
     });
-    const targets = queryResult.target.map((target: blaze_query.Target) => {
+    const targets = queryResult.target.map((target: blaze_query.ITarget) => {
       return new BazelTargetTreeItem(this.workspaceInfo, target);
     });
     return (this.directSubpackages as IBazelTreeItem[]).concat(targets);

--- a/src/workspace-tree/bazel_target_tree_item.ts
+++ b/src/workspace-tree/bazel_target_tree_item.ts
@@ -32,7 +32,7 @@ export class BazelTargetTreeItem
    */
   constructor(
     private readonly workspaceInfo: BazelWorkspaceInfo,
-    private readonly target: blaze_query.Target,
+    private readonly target: blaze_query.ITarget,
   ) {}
 
   public mightHaveChildren(): boolean {

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -183,7 +183,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
       ignoresErrors: true,
       sortByRuleName: true,
     });
-    const targets = queryResult.target.map((target: blaze_query.Target) => {
+    const targets = queryResult.target.map((target: blaze_query.ITarget) => {
       return new BazelTargetTreeItem(this.workspaceInfo, target);
     });
 

--- a/src/workspace-tree/icons.ts
+++ b/src/workspace-tree/icons.ts
@@ -25,7 +25,7 @@ import { blaze_query } from "../protos";
  * application/extension/framework targets are shown with folder-like icons
  * because those bundles are conceptually folders.
  */
-const SPECIFIC_RULE_CLASS_ICONS = {
+const SPECIFIC_RULE_CLASS_ICONS: Record<string, string> = {
   android_binary: "android_binary",
   apple_bundle_import: "resource_bundle",
   apple_resource_bundle: "resource_bundle",
@@ -59,10 +59,10 @@ const SPECIFIC_RULE_CLASS_ICONS = {
  * @param rule The {@code QueriedRule} representing the build target.
  */
 export function getBazelRuleIcon(
-  target: blaze_query.Target,
+  target: blaze_query.ITarget,
 ): string | vscode.ThemeIcon {
   const ruleClass = target.rule.ruleClass;
-  let iconName = SPECIFIC_RULE_CLASS_ICONS[ruleClass] as string;
+  let iconName = SPECIFIC_RULE_CLASS_ICONS[ruleClass];
   if (!iconName) {
     if (ruleClass.endsWith("_binary")) {
       iconName = "binary";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
         ],
         "sourceMap": true,
         "rootDir": ".",
-        "alwaysStrict": true,
-        "allowJs": true
+        "strict": true,
+        "strictNullChecks": false
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
This commit makes the TypeScript configuration stricter by enabling the `strict` setting. This implies that the `alwaysStrict` setting is implicitely enabled and no longer needs to be mentioned explicitly.

This required three fixes:
* in `icons.ts`, `SPECIFIC_RULE_CLASS_ICONS` needed an explicit type
* in `bazel_query.ts`, `execOptions` needed an explicit type
* All usages of `blaze_query.Target` had to be replaced by `ITarget`. This was necessary, because `queryResult.target` is of type `ITarget[]` not `Target` and `bazel_{package,target}_tree_item.ts` would not have compiled otherwise.

The `strictNullChecks` setting is explicitly opted-out. There are 117 violations against those stricter null checks, and to make the reviews easier, I plan to fix those in a separate commit.

I also removed the `allowJs` setting. Not sure why this was ever set. It doesn't seem to be required anymore.