### PR TITLE
Fix protobuffers build by re-enabling `allowJs`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "sourceMap": true,
         "rootDir": ".",
         "strict": true,
-        "strictNullChecks": false
+        "strictNullChecks": false,
+        "allowJs": true,
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
As part of #358, I removed the `allowJs` setting from the `tsconfig.json`. I didn't know why we needed `allowJs` and everything seemed to still work smoothly.

However, when trying to build the extension from a completely fresh git checkout, I realized that the `protos.js` file was missing from the `out` directory. With `allowJs: false` the `src/protos/protos.js` file was no longer copied to the `out` directory. This only worked locally for me, because the current build is not hermetic.