### PR TITLE
docs: Document how to use a distinct output base

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ this extension does not automatically _fix_ lint warnings during formatting,
 but you can opt into this by enabling the **Bazel: Buildifier Fix on Format**
 setting.
 
+### Using a separate output base
+
+By default this extension will use the default output base for running queries. This will cause builds to block queries, potentially causing degraded performance. In Bazel versions since 7.1 it is safe to disable this by changing the `bazel.queriesShareServer` setting to `false`. In earlier versions it can be safely disabled after adding the convenience symlinks to `.bazelignore`, for example:
+
+```
+bazel-myreponame
+bazel-bin
+bazel-testlogs
+```
+
+See [#216](https://github.com/bazelbuild/vscode-bazel/issues/216) and [bazelbuild/bazel#106539](https://github.com/bazelbuild/bazel/issues/10653).
+
 ## Using the Starlark Debugger
 
 Currently, the Starlark Debugger can be used by right-clicking a build target in

--- a/package.json
+++ b/package.json
@@ -136,8 +136,8 @@
                 },
                 "bazel.queriesShareServer": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Use the same Bazel server for queries and builds. By default, vscode-bazel uses a separate server for queries so that they can be executed in parallel with builds. You can enable this setting if running multiple Bazel servers has a negative performance impact on your system, but you may experience degraded performance in Visual Studio Code for operations that require queries."
+                    "default": "true",
+                    "description": "Use the same Bazel server for queries and builds. By default, vscode-bazel uses the same server for queries and builds to make sure this extension works out-of-the-box. However, you may experience degraded performance in Visual Studio Code for operations that require queries. You can disable this setting so that queries and builds can be executed in parallel in some circumstances. See https://github.com/bazelbuild/vscode-bazel?tab=readme-ov-file#using-a-separate-output-base for more information."
                 },
                 "bazel.queryOutputBase": {
                     "type": "string",


### PR DESCRIPTION
This flips the `bazel.queriesShareServer` default back to `true`, since I think it was a bit hasty in #355 to break everyone not on the latest bazel version. Instead, I have added a section to the docs, linked from the setting, describing how to safely disable this option.