### PR TITLE
docs: Update options for language servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Clicking the "Stop" button in the debugger will kill the Bazel process being
 debugger, allowing you to halt the current build. The Bazel server, however,
 will continue running.
 
-## Using the LSP (Experimental)
+## Using a language server (Experimental)
 
-This extension can use [Facebook's starlark project](https://github.com/facebookexperimental/starlark-rust) as a language server.
+Some of the functionality of this extension, such as go to definition and completions, can be replaced with a language server. There are currently two in-progress implementations of this:
 
-1. Install the LSP using cargo: `cargo install starlark_bin`
-2. Enable the LSP extension by setting `bazel.lsp.enabled` to `true`.
+- [bazel-lsp](https://github.com/cameron-martin/bazel-lsp): Based on Facebook's starlark project.
+- [starpls](https://github.com/withered-magic/starpls): Based on rust-analyzer.
+
+See the README of the corresponding repo for setup instructions.
 
 ## Bazel tasks
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Clicking the "Stop" button in the debugger will kill the Bazel process being
 debugger, allowing you to halt the current build. The Bazel server, however,
 will continue running.
 
-## Using a language server (Experimental)
+## Using a language server (experimental)
 
 This extension can use a language server for various features, such as go to definition and completions. There are currently two compatible language servers:
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ will continue running.
 
 This extension can use a language server for various features, such as go to definition and completions. There are currently two compatible language servers:
 
-- [bazel-lsp](https://github.com/cameron-martin/bazel-lsp): is based on Facebook's Starlark language server and extends it with additional, Bazel-specific functionality.
-- [starpls](https://github.com/withered-magic/starpls): is an implementation based on rust-analyzer which also provides Bazel-specific functionality.
+- [bazel-lsp](https://github.com/cameron-martin/bazel-lsp) is based on Facebook's Starlark language server and extends it with additional, Bazel-specific functionality.
+- [starpls](https://github.com/withered-magic/starpls) is an implementation based on rust-analyzer which also provides Bazel-specific functionality.
 
 In general, you need to install the language server binary and then set the `bazel.lsp.command` setting. See the README of the corresponding repo for more specific setup instructions.
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ will continue running.
 
 ## Using a language server (Experimental)
 
-Some of the functionality of this extension, such as go to definition and completions, can be replaced with a language server. There are currently two in-progress implementations of this:
+This extension can use a language server for various features, such as go to definition and completions. There are currently two compatible language servers:
 
-- [bazel-lsp](https://github.com/cameron-martin/bazel-lsp): Based on Facebook's starlark project.
-- [starpls](https://github.com/withered-magic/starpls): Based on rust-analyzer.
+- [bazel-lsp](https://github.com/cameron-martin/bazel-lsp): is based on Facebook's Starlark language server and extends it with additional, Bazel-specific functionality.
+- [starpls](https://github.com/withered-magic/starpls): is an implementation based on rust-analyzer which also provides Bazel-specific functionality.
 
-See the README of the corresponding repo for setup instructions.
+In general, you need to install the language server binary and then set the `bazel.lsp.command` setting. See the README of the corresponding repo for more specific setup instructions.
+
+We can't currently make any recommendation between these two. Both are under active development and are rapidly gaining more functionality.
 
 ## Bazel tasks
 

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
                 },
                 "bazel.lsp.command": {
                     "type": "string",
-                    "default": "starlark",
+                    "default": "",
                     "description": "The executable to launch for the LSP"
                 },
                 "bazel.lsp.args": {
@@ -196,10 +196,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": [
-                        "--lsp",
-                        "--bazel"
-                    ],
+                    "default": [],
                     "description": "The arguments to pass to the LSP executable"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -181,15 +181,10 @@
                     "default": "...:*",
                     "description": "A [query language expression](https://bazel.build/query/language) which determines the packages displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*`"
                 },
-                "bazel.lsp.enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enable the LSP (experimental)"
-                },
                 "bazel.lsp.command": {
                     "type": "string",
                     "default": "",
-                    "description": "The executable to launch for the LSP"
+                    "description": "The executable to launch for the LSP (experimental). Providing this disables certain features in the extension on the basis that they'll be provided by this language server."
                 },
                 "bazel.lsp.args": {
                     "type": "array",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -56,7 +56,7 @@ export async function activate(context: vscode.ExtensionContext) {
   completionItemProvider.refresh();
 
   const config = vscode.workspace.getConfiguration("bazel");
-  const lspEnabled = config.get<boolean>("lsp.enabled");
+  const lspEnabled = !!config.get<string>("lsp.command");
 
   if (lspEnabled) {
     const lspClient = createLsp(config);


### PR DESCRIPTION
Previously the docs suggested using facebook's proof-of-concept bazel language server, but there is a more up-to-date version available based on this. There is also another implementation, starpls, that is based on rust-analyzer. This also updates the default values of the lsp settings to not favour a particular language server.