### PR TITLE
fix: Add a welcome view to the Bazel Build Targets tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -440,7 +440,14 @@
                     "when": "bazel.haveWorkspace"
                 }
             ]
-        }
+        },
+        "viewsWelcome": [
+            {
+                "view": "bazelWorkspace",
+                "contents": "No Bazel targets found.\n[Refresh Target List](command:bazel.refreshBazelBuildTargets)",
+                "when": "bazel.haveWorkspace"
+            }
+        ]
     },
     "scripts": {
         "check-lint": "eslint",

--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -97,7 +97,7 @@ function shouldIgnorePath(fsPath: string): boolean {
  * Search for the path to the directory that has the Bazel WORKSPACE file for
  * the given file.
  *
- * If multiple directories along the path to the file has files called
+ * If multiple directories along the path to the file have files called
  * "WORKSPACE", the lowest path is returned.
  *
  * @param fsPath The path to a file in a Bazel workspace.


### PR DESCRIPTION
By showing a welcome view, we draw more attention to the "Refresh Target List" command. The "Refresh" command might otherwise be overlooked, in particular by newcomers to this extension which might be particularly prone to an empty build target list.