### PR TITLE
ci: Fix eslint integration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -176,12 +176,10 @@ module.exports = tseslint.config(
   },
   {
     files: ["eslint.config.js"],
+    // `@eslint/js` is currnetly missing type information.
+    // Re-enable the type checks as soon as we have type infos.
+    extends: [tseslint.configs.disableTypeChecked],
     rules: {
-      // `@eslint/js` is currnetly missing type information.
-      // Re-enable the following checks as soon as we have type infos.
-      "@typescript-eslint/no-unsafe-member-access": "off",
-      "@typescript-eslint/no-unsafe-argument": "off",
-      "@typescript-eslint/no-unsafe-assignment": "off",
       // Re-enable as soon as we are using ES modules for this config file.
       "@typescript-eslint/no-var-requires": "off",
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,172 +1,188 @@
-module.exports = {
-  files: ["src/**/*.ts"],
-  ignorePatterns: ["src/protos/protos.js", "src/protos/protos.d.ts"],
-  env: {
-    es6: true,
-    node: true,
+// @ts-check
+
+const globals = require("globals");
+const eslint = require("@eslint/js");
+const tseslint = require("typescript-eslint");
+const jsdoc = require("eslint-plugin-jsdoc");
+const eslintConfigPrettier = require("eslint-config-prettier");
+
+module.exports = tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintConfigPrettier,
+  {
+    ignores: ["out/", "src/protos/protos.js", "src/protos/protos.d.ts"],
   },
-  extends: [
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "prettier",
-  ],
-  parser: "@typescript-eslint/parser",
-  parserOptions: {
-    project: "tsconfig.json",
-    sourceType: "module",
-  },
-  plugins: [
-    "eslint-plugin-jsdoc",
-    "eslint-plugin-prefer-arrow",
-    "@typescript-eslint",
-  ],
-  root: true,
-  rules: {
-    "@typescript-eslint/adjacent-overload-signatures": "error",
-    "@typescript-eslint/array-type": [
-      "error",
-      {
-        default: "array",
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
       },
-    ],
-    "@typescript-eslint/ban-types": [
-      "error",
-      {
-        types: {
-          Object: {
-            message: "Avoid using the `Object` type. Did you mean `object`?",
-          },
-          Function: {
-            message:
-              "Avoid using the `Function` type. Prefer a specific function type, like `() => void`.",
-          },
-          Boolean: {
-            message: "Avoid using the `Boolean` type. Did you mean `boolean`?",
-          },
-          Number: {
-            message: "Avoid using the `Number` type. Did you mean `number`?",
-          },
-          String: {
-            message: "Avoid using the `String` type. Did you mean `string`?",
-          },
-          Symbol: {
-            message: "Avoid using the `Symbol` type. Did you mean `symbol`?",
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: {
+      jsdoc,
+    },
+    rules: {
+      "@typescript-eslint/adjacent-overload-signatures": "error",
+      "@typescript-eslint/array-type": [
+        "error",
+        {
+          default: "array",
+        },
+      ],
+      "@typescript-eslint/ban-types": [
+        "error",
+        {
+          types: {
+            Object: {
+              message: "Avoid using the `Object` type. Did you mean `object`?",
+            },
+            Function: {
+              message:
+                "Avoid using the `Function` type. Prefer a specific function " +
+                "type, like `() => void`.",
+            },
+            // eslint-disable-next-line id-denylist
+            Boolean: {
+              message:
+                "Avoid using the `Boolean` type. Did you mean `boolean`?",
+            },
+            // eslint-disable-next-line id-denylist
+            Number: {
+              message: "Avoid using the `Number` type. Did you mean `number`?",
+            },
+            // eslint-disable-next-line id-denylist
+            String: {
+              message: "Avoid using the `String` type. Did you mean `string`?",
+            },
+            Symbol: {
+              message: "Avoid using the `Symbol` type. Did you mean `symbol`?",
+            },
           },
         },
-      },
-    ],
-    "@typescript-eslint/consistent-type-assertions": "error",
-    "@typescript-eslint/dot-notation": "error",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/naming-convention": [
-      "error",
-      {
-        selector: "variable",
-        format: ["camelCase", "UPPER_CASE", "PascalCase"],
-        leadingUnderscore: "allow",
-        trailingUnderscore: "forbid",
-      },
-    ],
-    "@typescript-eslint/no-empty-function": "error",
-    "@typescript-eslint/no-empty-interface": "error",
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-floating-promises": "error",
-    "@typescript-eslint/no-misused-new": "error",
-    "@typescript-eslint/no-namespace": "error",
-    "@typescript-eslint/no-parameter-properties": "off",
-    "@typescript-eslint/no-shadow": [
-      "error",
-      {
-        hoist: "all",
-      },
-    ],
-    "@typescript-eslint/no-unused-expressions": "error",
-    "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/no-var-requires": "error",
-    "@typescript-eslint/prefer-for-of": "error",
-    "@typescript-eslint/prefer-function-type": "error",
-    "@typescript-eslint/prefer-namespace-keyword": "error",
-    "@typescript-eslint/triple-slash-reference": [
-      "error",
-      {
-        path: "always",
-        types: "prefer-import",
-        lib: "always",
-      },
-    ],
-    "@typescript-eslint/typedef": "off",
-    "@typescript-eslint/unified-signatures": "error",
-    complexity: "off",
-    "constructor-super": "error",
-    "dot-notation": "off",
-    eqeqeq: ["error", "smart"],
-    "guard-for-in": "error",
-    "id-denylist": [
-      "error",
-      "any",
-      "Number",
-      "number",
-      "String",
-      "string",
-      "Boolean",
-      "boolean",
-      "Undefined",
-      "undefined",
-    ],
-    "id-match": "error",
-    "jsdoc/check-alignment": "error",
-    "jsdoc/check-indentation": "error",
-    "max-classes-per-file": ["error", 1],
-    "max-len": [
-      "error",
-      {
-        ignorePattern: "^(import |export)",
-        ignoreComments: true,
-        ignoreTemplateLiterals: true,
-        code: 80,
-      },
-    ],
-    "new-parens": "error",
-    "no-bitwise": "error",
-    "no-caller": "error",
-    "no-cond-assign": "error",
-    "no-console": "error",
-    "no-debugger": "error",
-    "no-empty": "error",
-    "no-empty-function": "off",
-    "no-eval": "error",
-    "no-fallthrough": "off",
-    "no-invalid-this": "off",
-    "no-new-wrappers": "error",
-    "no-shadow": "off",
-    "no-throw-literal": "error",
-    "no-trailing-spaces": "error",
-    "no-undef-init": "error",
-    "no-underscore-dangle": "off",
-    "no-unsafe-finally": "error",
-    "no-unused-expressions": "off",
-    "no-unused-labels": "error",
-    "no-use-before-define": "off",
-    "no-var": "error",
-    "object-shorthand": "error",
-    "one-var": ["error", "never"],
-    "prefer-arrow/prefer-arrow-functions": [
-      "error",
-      {
-        allowStandaloneDeclarations: true,
-      },
-    ],
-    "prefer-const": "error",
-    radix: "error",
-    "spaced-comment": [
-      "error",
-      "always",
-      {
-        markers: ["/"],
-      },
-    ],
-    "use-isnan": "error",
-    "valid-typeof": "off",
+      ],
+      "@typescript-eslint/consistent-type-assertions": "error",
+      "@typescript-eslint/dot-notation": "error",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: "variable",
+          format: ["camelCase", "UPPER_CASE", "PascalCase"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "forbid",
+        },
+      ],
+      "@typescript-eslint/no-empty-function": "error",
+      "@typescript-eslint/no-empty-interface": "error",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/no-namespace": "error",
+      "@typescript-eslint/no-parameter-properties": "off",
+      "@typescript-eslint/no-shadow": [
+        "error",
+        {
+          hoist: "all",
+        },
+      ],
+      "@typescript-eslint/no-unused-expressions": "error",
+      "@typescript-eslint/no-use-before-define": "off",
+      "@typescript-eslint/no-var-requires": "error",
+      "@typescript-eslint/prefer-for-of": "error",
+      "@typescript-eslint/prefer-function-type": "error",
+      "@typescript-eslint/prefer-namespace-keyword": "error",
+      "@typescript-eslint/triple-slash-reference": [
+        "error",
+        {
+          path: "always",
+          types: "prefer-import",
+          lib: "always",
+        },
+      ],
+      "@typescript-eslint/typedef": "off",
+      "@typescript-eslint/unified-signatures": "error",
+      complexity: "off",
+      "constructor-super": "error",
+      "dot-notation": "off",
+      eqeqeq: ["error", "smart"],
+      "guard-for-in": "error",
+      "id-denylist": [
+        "error",
+        "any",
+        "Number",
+        "number",
+        "String",
+        "string",
+        "Boolean",
+        "boolean",
+        "Undefined",
+        "undefined",
+      ],
+      "id-match": "error",
+      "jsdoc/check-alignment": "error",
+      "jsdoc/check-indentation": "error",
+      "max-len": [
+        "error",
+        {
+          ignorePattern: "^(import |export)",
+          ignoreComments: true,
+          ignoreTemplateLiterals: true,
+          code: 80,
+        },
+      ],
+      "new-parens": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-cond-assign": "error",
+      "no-console": "error",
+      "no-debugger": "error",
+      "no-empty": "error",
+      "no-empty-function": "off",
+      "no-eval": "error",
+      "no-fallthrough": "off",
+      "no-invalid-this": "off",
+      "no-new-wrappers": "error",
+      "no-shadow": "off",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "error",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unsafe-finally": "error",
+      "no-unused-expressions": "off",
+      "no-unused-labels": "error",
+      "no-use-before-define": "off",
+      "no-var": "error",
+      "object-shorthand": "error",
+      "one-var": ["error", "never"],
+      "prefer-arrow-callback": "error",
+      "prefer-const": "error",
+      radix: "error",
+      "spaced-comment": [
+        "error",
+        "always",
+        {
+          markers: ["/"],
+        },
+      ],
+      "use-isnan": "error",
+      "valid-typeof": "off",
+    },
   },
-};
+  {
+    files: ["eslint.config.js"],
+    rules: {
+      // `@eslint/js` is currnetly missing type information.
+      // Re-enable the following checks as soon as we have type infos.
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      // Re-enable as soon as we are using ES modules for this config file.
+      "@typescript-eslint/no-var-requires": "off",
+    }
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,13 +20,12 @@
                 "@types/node": "^16.11.7",
                 "@types/vscode": "^1.85.0",
                 "@types/which": "^3.0.3",
-                "@typescript-eslint/eslint-plugin": "^7.5.0",
-                "@typescript-eslint/parser": "^7.5.0",
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-jsdoc": "^48.2.2",
                 "eslint-plugin-prefer-arrow": "^1.2.3",
-                "typescript": "^5.4.3"
+                "typescript": "^5.4.4",
+                "typescript-eslint": "^7.5.0"
             },
             "engines": {
                 "vscode": "^1.85.0"
@@ -2011,9 +2010,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+            "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -2021,6 +2020,32 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.5.0.tgz",
+            "integrity": "sha512-eKhF39LRi2xYvvXh3h3S+mCxC01dZTIZBlka25o39i81VeQG+OZyfC4i2GEDspNclMRdXkg9uGhmvWMhjph2XQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "7.5.0",
+                "@typescript-eslint/parser": "7.5.0",
+                "@typescript-eslint/utils": "7.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/uri-js": {
@@ -3577,10 +3602,21 @@
             "dev": true
         },
         "typescript": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+            "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
             "dev": true
+        },
+        "typescript-eslint": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.5.0.tgz",
+            "integrity": "sha512-eKhF39LRi2xYvvXh3h3S+mCxC01dZTIZBlka25o39i81VeQG+OZyfC4i2GEDspNclMRdXkg9uGhmvWMhjph2XQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/eslint-plugin": "7.5.0",
+                "@typescript-eslint/parser": "7.5.0",
+                "@typescript-eslint/utils": "7.5.0"
+            }
         },
         "uri-js": {
             "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-jsdoc": "^48.2.2",
-                "eslint-plugin-prefer-arrow": "^1.2.3",
                 "typescript": "^5.4.4",
                 "typescript-eslint": "^7.5.0"
             },
@@ -947,15 +946,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
-        },
-        "node_modules/eslint-plugin-prefer-arrow": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-            "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-            "dev": true,
-            "peerDependencies": {
-                "eslint": ">=2.0.0"
-            }
         },
         "node_modules/eslint-scope": {
             "version": "7.2.2",
@@ -2920,13 +2910,6 @@
                     "dev": true
                 }
             }
-        },
-        "eslint-plugin-prefer-arrow": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-            "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-            "dev": true,
-            "requires": {}
         },
         "eslint-scope": {
             "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -443,22 +443,21 @@
         }
     },
     "scripts": {
-        "check-lint": "eslint",
+        "check-lint": "eslint .",
         "compile": "./scripts/build.sh",
         "vscode:prepublish": "./scripts/build.sh",
         "watch": "./scripts/build.sh -watch"
     },
     "devDependencies": {
         "@types/node": "^16.11.7",
-        "@types/which": "^3.0.3",
         "@types/vscode": "^1.85.0",
-        "@typescript-eslint/eslint-plugin": "^7.5.0",
-        "@typescript-eslint/parser": "^7.5.0",
+        "@types/which": "^3.0.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jsdoc": "^48.2.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
-        "typescript": "^5.4.3"
+        "typescript": "^5.4.4",
+        "typescript-eslint": "^7.5.0"
     },
     "dependencies": {
         "protobufjs": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -455,7 +455,6 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jsdoc": "^48.2.2",
-        "eslint-plugin-prefer-arrow": "^1.2.3",
         "typescript": "^5.4.4",
         "typescript-eslint": "^7.5.0"
     },

--- a/src/bazel/bazel_workspace_info.ts
+++ b/src/bazel/bazel_workspace_info.ts
@@ -81,11 +81,12 @@ export class BazelWorkspaceInfo {
         return undefined;
       case 1:
         return this.fromWorkspaceFolder(vscode.workspace.workspaceFolders[0]);
-      default:
+      default: {
         const workspaceFolder = await vscode.window.showWorkspaceFolderPick();
         return workspaceFolder
           ? this.fromWorkspaceFolder(workspaceFolder)
           : undefined;
+      }
     }
   }
 

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -96,7 +96,7 @@ export async function buildifierLint(
   switch (lintMode) {
     case "fix":
       return outputs.stdout;
-    case "warn":
+    case "warn": {
       const result = JSON.parse(outputs.stdout) as IBuildifierResult;
       for (const file of result.files) {
         if (file.filename === "<stdin>") {
@@ -104,6 +104,7 @@ export async function buildifierLint(
         }
       }
       return [];
+    }
   }
 }
 

--- a/src/debug-adapter/connection.ts
+++ b/src/debug-adapter/connection.ts
@@ -154,6 +154,7 @@ export class BazelDebugConnection extends EventEmitter {
     let event: skylark_debugging.DebugEvent = null;
     this.append(chunk);
 
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
         event = skylark_debugging.DebugEvent.decodeDelimited(this.reader);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -157,6 +157,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // users closes the "Buildifier not found" notification. VS Code hence
   // dislayed  never-finishing "Loading" indicator on top of the "Bazel Build
   // Targets" tree view.
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   checkBuildifierIsAvailable();
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     },
     "exclude": [
         "node_modules",
-        "out"
+        "out",
+        "eslint.config.js"
     ]
 }


### PR DESCRIPTION
In #363, I accidentally disabled all eslint checks: I used `eslint` and thought this would actually run the linter on the complete source tree. Starting from ESLint 9.0, this will actually work (See https://eslint.org/blog/2024/04/eslint-v9.0.0-released/#running-eslint-with-no-file-arguments). But for ESLint 8.x, we still need to use `eslint .`

This commit fixes that oversight in `package.json` and rectifies all the fall-out from this mistake.

First, I finished the migration to the new eslint.config.js format. To avoid further bugs, I first enabled TypeScript's type checking via `@ts-check`. I then followed the migration guide from https://eslint.org/docs/latest/use/configure/migration-guide to fix the config in general.

Doing so, I changed a the linter config in the following way:
* I disabled the `max-classes-per-file` linter rule. My change #365 violated this rule. But I don't think that this rule provides much value in general. Having one class per file is rather a Java convention than a JavaScript convention...
* I replaced `prefer-arrow/prefer-arrow-functions` by the built-in `prefer-arrow-callback`. Afaict, those checks do the same. This allowed me to remove the dependency on the package `eslint-plugin-prefer-arrow`.
* The linting actually alos applied to the `eslint.config.js` file itself. But  not all packages have types, zet. I hence disabled a couple of rules for this file.

With that out-of-the way, I had to fix the actual lint warnings:
* In `eslint-plugin-prefer-arrow bazel_workspace_info.ts and buildifier.ts: "Unexpected lexical declaration in case block"
* extension.ts had an (intentionally) dangling promise
* debug-adapter/connection.ts had an intentional `while(true)` loop.