### PR TITLE
ci: Integrate `prettier` formatting

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,10 +18,6 @@ tasks:
       - npm ci
       - npm run compile
       - npm run check-lint
-      # TODO(allevato): Add a prettier check to verify that *.ts files don't
-      # differ from their prettier output. We need `prettier-tslint` so that
-      # prettier will obey our tslint config, but it doesn't support
-      # Typescript 3 yet.
-      # (https://github.com/azz/prettier-tslint/issues/18)
+      - npm run format-check
     build_targets:
       - "//:dummy_target_for_ci"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 *.json
+src/protos/protos.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -182,5 +182,6 @@ module.exports = tseslint.config(
     rules: {
       // Re-enable as soon as we are using ES modules for this config file.
       "@typescript-eslint/no-var-requires": "off",
-    }
-  });
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-jsdoc": "^48.2.2",
+                "prettier": "^3.2.5",
                 "typescript": "^5.4.4",
                 "typescript-eslint": "^7.5.0"
             },
@@ -1754,6 +1755,21 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prettier": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/protobufjs": {
             "version": "6.8.8",
             "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
@@ -3419,6 +3435,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
             "dev": true
         },
         "protobufjs": {

--- a/package.json
+++ b/package.json
@@ -444,6 +444,8 @@
     "scripts": {
         "check-lint": "eslint .",
         "compile": "./scripts/build.sh",
+        "format-check": "prettier --check .",
+        "format-fix": "prettier --write .",
         "vscode:prepublish": "./scripts/build.sh",
         "watch": "./scripts/build.sh -watch"
     },
@@ -454,6 +456,7 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jsdoc": "^48.2.2",
+        "prettier": "^3.2.5",
         "typescript": "^5.4.4",
         "typescript-eslint": "^7.5.0"
     },

--- a/src/completion-provider/bazel_completion_provider.ts
+++ b/src/completion-provider/bazel_completion_provider.ts
@@ -90,7 +90,8 @@ function getAbsoluteLabel(
 }
 
 export class BazelCompletionItemProvider
-  implements vscode.CompletionItemProvider {
+  implements vscode.CompletionItemProvider
+{
   private targets: string[] = [];
 
   /**


### PR DESCRIPTION
So far, the code formatting was not checked by the CI. Now it is. To do so, this commit introduces a new `check-format` npm command. I did not use the `eslint-prettier` plugin because the guidance on https://prettier.io/docs/en/integrating-with-linters.html recommends against doing so.