### PR TITLE
ci: Make prettier ignore changelog

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 *.json
 src/protos/protos.js
+CHANGELOG.md


### PR DESCRIPTION
This changelog is auto-generated by release please and fails prettier checks, so this is now ignored by prettier.