### PR TITLE
fix: Link the full label / file name instead of individual components

### DIFF
--- a/src/definition/bazel_goto_definition_provider.ts
+++ b/src/definition/bazel_goto_definition_provider.ts
@@ -59,12 +59,18 @@ export class BazelGotoDefinitionProvider implements DefinitionProvider {
       return null;
     }
     const result = queryResult.target[0];
+    let location;
     if (result.type === blaze_query.Target.Discriminator.RULE) {
-      const location = new QueryLocation(result.rule.location);
-      return new Location(Uri.file(location.path), location.range);
+      location = new QueryLocation(result.rule.location);
     } else {
-      const location = new QueryLocation(result.sourceFile.location);
-      return new Location(Uri.file(location.path), new Position(0, 0));
+      location = new QueryLocation(result.sourceFile.location);
     }
+    return [
+      {
+        originSelectionRange: range,
+        targetUri: Uri.file(location.path),
+        targetRange: location.range,
+      },
+    ];
   }
 }

--- a/src/definition/bazel_goto_definition_provider.ts
+++ b/src/definition/bazel_goto_definition_provider.ts
@@ -16,7 +16,6 @@ import {
   Definition,
   DefinitionLink,
   DefinitionProvider,
-  Location,
   Position,
   TextDocument,
   Uri,


### PR DESCRIPTION
So far, the `go_to_definition` provider did not provide a `originSelectionRange`. Hence, VS Code was falling back on its internal tokenization to decide which part of the text to provide the HyperLink for.

For the label "my/package:file.txt", we hence linked `my`, `package`, `file` and `txt` individually, all pointing to the same file.

With this change, we now instead always provide the link on the full label.