### PR TITLE
feat (coverage): Load branch coverage from coverage files

### DIFF
--- a/src/test-explorer/lcov_parser.ts
+++ b/src/test-explorer/lcov_parser.ts
@@ -46,8 +46,8 @@ export function parseLcov(
   // Note that line numbers in LCOV files seem to be 1-based, while line
   // numbers for VS Code need to be 0-based.
   class FileCoverageInfo {
-    functionsByLine: Map<Number, vscode.DeclarationCoverage> = new Map();
-    lineCoverage: Map<Number, vscode.StatementCoverage> = new Map();
+    functionsByLine: Map<number, vscode.DeclarationCoverage> = new Map();
+    lineCoverage: Map<number, vscode.StatementCoverage> = new Map();
     coverageByLineAndBranch: Map<number, Map<string, vscode.BranchCoverage>> =
       new Map();
   }
@@ -200,12 +200,12 @@ export function parseLcov(
           if (!match) {
             throw new Error(`Invalid FNDA entry`);
           }
-          const lineNumber = Number.parseInt(match[1]) - 1;
+          const lineNumber = Number.parseInt(match[1], 10) - 1;
           if (lineNumber < 0) {
             throw new Error("Negative line number in DA entry");
           }
           const isException = match[2] === "e";
-          const blockId = Number.parseInt(match[3]);
+          const blockId = Number.parseInt(match[3], 10);
           const rest = match[4];
           const commaOffset = rest.lastIndexOf(",");
           if (commaOffset === undefined) {
@@ -214,7 +214,7 @@ export function parseLcov(
           const label = rest.substring(0, commaOffset);
           const hitCountStr = rest.substring(commaOffset + 1);
           const hitCount =
-            hitCountStr == "-" ? 0 : Number.parseInt(hitCountStr);
+            hitCountStr === "-" ? 0 : Number.parseInt(hitCountStr, 10);
           if (hitCount < 0) {
             throw new Error("Negative hit count in DA entry");
           }

--- a/test/lcov_parser.test.ts
+++ b/test/lcov_parser.test.ts
@@ -89,7 +89,9 @@ describe("The lcov parser", () => {
       assert.strictEqual(fileCov.statementCoverage.covered, 11);
     });
     it("branch coverage", () => {
-      assert(fileCov.branchCoverage === undefined);
+      assert(fileCov.branchCoverage !== undefined);
+      assert.strictEqual(fileCov.branchCoverage.total, 6);
+      assert.strictEqual(fileCov.branchCoverage.covered, 3);
     });
     it("function coverage details", () => {
       const initFunc = getFunctionByLine(fileCov, 24);
@@ -108,6 +110,12 @@ describe("The lcov parser", () => {
       assert.equal(getLineCoverageForLine(fileCov, 37).executed, 1);
       assert.equal(getLineCoverageForLine(fileCov, 38).executed, 0);
       assert.equal(getLineCoverageForLine(fileCov, 40).executed, 1);
+    });
+    it("branch coverage data", () => {
+      const branchCoverage = getLineCoverageForLine(fileCov, 37).branches;
+      assert.equal(branchCoverage.length, 2);
+      assert.equal(branchCoverage[0].executed, 1);
+      assert.equal(branchCoverage[1].executed, 0);
     });
   });
 
@@ -128,7 +136,9 @@ describe("The lcov parser", () => {
       assert.strictEqual(fileCov.statementCoverage.covered, 505);
     });
     it("branch coverage", () => {
-      assert(fileCov.branchCoverage === undefined);
+      assert(fileCov.branchCoverage !== undefined);
+      assert.strictEqual(fileCov.branchCoverage.total, 2560);
+      assert.strictEqual(fileCov.branchCoverage.covered, 843);
     });
     it("function coverage details", () => {
       const initFunc = getFunctionByLine(fileCov, 71);
@@ -140,6 +150,14 @@ describe("The lcov parser", () => {
       assert.equal(getLineCoverageForLine(fileCov, 176).executed, 1);
       assert.equal(getLineCoverageForLine(fileCov, 178).executed, 0);
       assert.equal(getLineCoverageForLine(fileCov, 193).executed, 4);
+    });
+    it("branch coverage data", () => {
+      const branchCoverage = getLineCoverageForLine(fileCov, 479).branches;
+      assert.equal(branchCoverage.length, 2);
+      assert.equal(branchCoverage[0].executed, 1);
+      assert.equal(branchCoverage[1].executed, 0);
+      const branchCoverage2 = getLineCoverageForLine(fileCov, 481).branches;
+      assert.equal(branchCoverage2.length, 12);
     });
   });
 
@@ -161,6 +179,8 @@ describe("The lcov parser", () => {
       assert.strictEqual(fileCov.statementCoverage.covered, 426);
     });
     it("branch coverage", () => {
+      // Rust has no branch coverage data, as of writing this test case.
+      // Also see https://github.com/rust-lang/rust/issues/79649
       assert(fileCov.branchCoverage === undefined);
     });
     it("function coverage details", () => {
@@ -194,6 +214,7 @@ describe("The lcov parser", () => {
       assert.strictEqual(fileCov.statementCoverage.covered, 133);
     });
     it("branch coverage", () => {
+      // Go has no branch coverage data.
       assert(fileCov.branchCoverage === undefined);
     });
     it("line coverage details", () => {


### PR DESCRIPTION
This commit teaches the LCOV parser to also read branch coverage data.

Works towards #362
