### PR TITLE
ci: Fix test invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -462,7 +462,6 @@
         "check-lint": "eslint .",
         "compile": "./scripts/build.sh",
         "pretest": "./scripts/build.sh",
-        "test": "vscode-test",
         "format-check": "prettier --check .",
         "format-fix": "prettier --write .",
         "test": "./scripts/test.sh",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,3 +25,6 @@ js-yaml syntaxes/bazelrc.tmLanguage.yaml > syntaxes/bazelrc.tmLanguage.json
 
 # Regression test for bazelrc grammar
 vscode-tmgrammar-snap "$@" test/example.bazelrc
+
+# Java Script tests
+vscode-test


### PR DESCRIPTION
During the rebase of #366, I accidentally duplicated the `test` key
inside the `scripts` in `package.json`. There was no warning whatsoever
and CI was still green, but didn't actually run the `vscode-test` tests.

This commit fixes the mishap
