### PR TITLE
ci: Don't run release-please in forks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'bazelbuild/vscode-bazel' }}
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release


### PR DESCRIPTION
I don't want release-please to create any pull requests in my fork. I
guess most other contributors have no use for those pull requests,
either.
