### PR TITLE
feat(coverage): Demangling C++ & Rust function names in coverage results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Required for the test cases
       - name: Install system dependencies
-        run: sudo apt install -y c++filt rustfilt
+        run: sudo apt install -y binutils rustfilt
 
       - run: xvfb-run -a npm test
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Lint
         run: npm run check-lint
 
+      # Required for the test cases
+      - name: Install system dependencies
+        run: sudo apt install -y c++filt rustfilt
+
       - run: xvfb-run -a npm test
         if: runner.os == 'Linux'
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ In case you are using the code coverage integration with any other language
 bazelbuild/vscode-bazel#367. Please share both positive and negative experiences
 you might have.
 
+For C++ and Rust, make sure to have `c++filt` / `rustfilt` installed and
+available through the `$PATH`. Otherwise, only mangled, hard-to-decipher
+function names will be displayed. For Java, no additional steps are required.
+
 ## Contributing
 
 If you would like to contribute to the Bazel Visual Studio extension, please

--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -184,7 +184,7 @@ async function onTaskProcessEnd(event: vscode.TaskProcessEndEvent) {
         );
       } else {
         // Show the coverage date
-        showLcovCoverage(
+        await showLcovCoverage(
           description,
           workspaceInfo.bazelWorkspacePath,
           covFileStr,

--- a/src/test-explorer/index.ts
+++ b/src/test-explorer/index.ts
@@ -31,7 +31,7 @@ export function activateTesting(): vscode.Disposable[] {
 /**
  * Display coverage information from a `.lcov` file.
  */
-export function showLcovCoverage(
+export async function showLcovCoverage(
   description: string,
   baseFolder: string,
   lcov: string,
@@ -42,7 +42,7 @@ export function showLcovCoverage(
     false,
   );
   run.appendOutput(description.replaceAll("\n", "\r\n"));
-  for (const c of parseLcov(baseFolder, lcov)) {
+  for (const c of await parseLcov(baseFolder, lcov)) {
     run.addCoverage(c);
   }
   run.end();

--- a/src/test-explorer/lcov_parser.ts
+++ b/src/test-explorer/lcov_parser.ts
@@ -123,8 +123,8 @@ async function demangleNameUsingFilter(
 ): Promise<string | undefined> {
   if (execPath === null) return undefined;
   const unmangled = (await execFile(execPath, [mangled])).stdout.trim();
-  // If unmangling failed, return undefined, so we could fallback to another demangler.
-  if (!unmangled || unmangled == mangled) return undefined;
+  // If unmangling failed, return undefined, so we can fallback to another demangler.
+  if (!unmangled || unmangled === mangled) return undefined;
   return unmangled;
 }
 

--- a/test/lcov_parser.test.ts
+++ b/test/lcov_parser.test.ts
@@ -6,7 +6,7 @@ import { DeclarationCoverage, StatementCoverage } from "vscode";
 
 const testDir = path.join(__dirname, "../..", "test");
 
-function parseTestLcov(lcov: string): BazelFileCoverage[] {
+function parseTestLcov(lcov: string): Promise<BazelFileCoverage[]> {
   return parseLcov("/base", lcov);
 }
 
@@ -50,19 +50,23 @@ function getLineCoverageForLine(
 }
 
 describe("The lcov parser", () => {
-  it("accepts an empty string", () => {
-    assert.deepEqual(parseTestLcov(""), []);
+  it("accepts an empty string", async () => {
+    assert.deepEqual(await parseTestLcov(""), []);
   });
 
-  it("accepts Linux end-of-lines", () => {
-    const coveredFiles = parseTestLcov("SF:a.cpp\nFN:1,abc\nend_of_record\n");
+  it("accepts Linux end-of-lines", async () => {
+    const coveredFiles = await parseTestLcov(
+      "SF:a.cpp\nFN:1,abc\nend_of_record\n",
+    );
     assert.equal(coveredFiles.length, 1);
     assert.equal(coveredFiles[0].declarationCoverage.total, 1);
   });
 
-  it("accepts Windows end-of-lines", () => {
+  it("accepts Windows end-of-lines", async () => {
     // \r\n and no final end of line
-    const coveredFiles = parseTestLcov("SF:a.cpp\r\nFN:1,abc\r\nend_of_record");
+    const coveredFiles = await parseTestLcov(
+      "SF:a.cpp\r\nFN:1,abc\r\nend_of_record",
+    );
     assert.equal(coveredFiles.length, 1);
     assert.equal(coveredFiles[0].declarationCoverage.total, 1);
   });
@@ -142,7 +146,7 @@ describe("The lcov parser", () => {
     it("function coverage details", () => {
       const initFunc = getFunctionByLine(fileCov, 71);
       assert(initFunc !== undefined);
-      assert.equal(initFunc.name, "_ZN5blaze10RcFileTest5SetUpEv");
+      assert.equal(initFunc.name, "blaze::RcFileTest::SetUp()");
       assert.equal(initFunc.executed, 34);
     });
     it("line coverage details", () => {
@@ -187,7 +191,7 @@ describe("The lcov parser", () => {
       assert(consumeFunc !== undefined);
       assert.equal(
         consumeFunc.name,
-        "_RNCNvCscQvVXOS7Ja3_5label20consume_package_name0B3_",
+        "label::consume_package_name::{closure#0}",
       );
       assert.equal(consumeFunc.executed, 2);
     });


### PR DESCRIPTION
Demangle C++ and Rust symbols using `c++filt` and `rustfilt`. We rely on those tools to be installed on the `$PATH`.

I was also considering whether I should compile `c++filt` and / or `rustfilt` to WebAssembly, but decided against it, given that this would make the build much more complicated and it is currently unclear to me whether we will stick with the "traditional" tool chains (npm, webpack, cargo, ...) or if we will pivot to using Bazel.