### PR TITLE
feat(codelens): Skip target names for one line targets

### DIFF
--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -131,6 +131,12 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
       name: string;
     }
 
+    const useTargetMap = queryResult.target
+      .map((t) => new QueryLocation(t.rule.location).line)
+      .reduce((countMap, line) => {
+        countMap.set(line, countMap.has(line));
+        return countMap;
+      }, new Map<number, boolean>());
     for (const target of queryResult.target) {
       const location = new QueryLocation(target.rule.location);
       const targetName = target.rule.name;
@@ -172,7 +178,8 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
       }
 
       for (const command of commands) {
-        const title = `${command.name} ${targetShortName}`;
+        const tooltip = `${command.name} ${targetShortName}`;
+        const title = useTargetMap.get(location.line) ? tooltip : command.name;
         result.push(
           new vscode.CodeLens(location.range, {
             arguments: [
@@ -180,7 +187,7 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
             ],
             command: command.commandString,
             title,
-            tooltip: title,
+            tooltip,
           }),
         );
       }


### PR DESCRIPTION
Current codlens commands look like:
<img width="940" alt="Screenshot 2024-07-04 at 07 18 08" src="https://github.com/bazelbuild/vscode-bazel/assets/1139997/62e5af4c-cb0f-4dfd-bff8-5a800826389b">
