### PR TITLE
fix(codelens): Apply commandArgs to run targets

### DIFF
--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -227,7 +227,10 @@ export function createBazelTaskFromDefinition(
     vscode.workspace.getConfiguration("bazel.commandLine");
   const startupOptions = bazelConfigCmdLine.get<string[]>("startupOptions");
   const addCommandArgs =
-    command === "build" || command === "test" || command === "coverage";
+    command === "build" ||
+    command === "test" ||
+    command === "coverage" ||
+    command === "run";
   const commandArgs = addCommandArgs
     ? bazelConfigCmdLine.get<string[]>("commandArgs")
     : [];


### PR DESCRIPTION
Currently, commandArgs is only applied to debug, test and coverage targets, not run targets, which is inconsistent: clicking a "build" codelens for a component and then clicking a "run" codelens for a runnable target which depends on that component ends up rebuilding it with a different configuration (e.g debug/optimized, remote/local build). It would be much more consistent if commandArgs applied to run targets.

This fixes #394.