### PR TITLE
fix: Change explorer UI label to "Bazel Targets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This extension provides support for Bazel in Visual Studio.
 ## Features
 
 - Syntax highlighting
-- **Bazel Build Targets** tree displays the build packages/targets in your
+- **Bazel Targets** tree displays the build packages/targets in your
   workspace
 - **CodeLens** links in BUILD files to directly launch a build or test by simply
   clicking on the targets

--- a/package.json
+++ b/package.json
@@ -445,7 +445,7 @@
             "explorer": [
                 {
                     "id": "bazelWorkspace",
-                    "name": "Bazel Build Targets",
+                    "name": "Bazel Targets",
                     "when": "bazel.haveWorkspace"
                 }
             ]


### PR DESCRIPTION
Hello, docs lead for pigweed.dev here. We're using your extension in an upcoming tutorial. Labeling this UI as `Bazel Build Targets` might give some the impression that this UI is only used for building binaries (or apps or whatever), when in reality we do a lot of things through this UI: run tests, flash binaries to devices, connect to a device over a console, etc. I think renaming to the more general `Bazel Targets` will therefore make it easier for people to grok that you can do lots of other things through this UI, so long as there's a Bazel target for it.

You all are welcome to change it to something else if you don't like `Bazel Targets`, my main feedback is to just drop the `Build` part from the label. I understand that the meaning here was probably "Targets From The Bazel Build System" but hopefully you can see the potential incorrect mental model that the current label might cause.