### PR TITLE
feat(config): add an option to fully disable queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ this extension does not automatically _fix_ lint warnings during formatting,
 but you can opt into this by enabling the **Bazel: Buildifier Fix on Format**
 setting.
 
+### Disabling Bazel Queries
+
+If you experience performance issues or want to reduce Bazel server load, you can disable all Bazel queries by setting **Bazel: Enable Queries** to `false`. When disabled, the following features will not work:
+
+- Bazel Targets tree view
+- Target completion in quick pick dialogs
+- CodeLens actions in BUILD files
+- Go-to-definition for Bazel targets
+- Symbol provider for BUILD files
+
+This setting is enabled by default to provide the full feature set, but disabling it can significantly improve performance in large workspaces.
+
 ### Using a separate output base
 
 By default this extension will use the default output base for running queries. This will cause builds to block queries, potentially causing degraded performance. In Bazel versions since 7.1 it is safe to disable this by changing the `bazel.queriesShareServer` setting to `false`. In earlier versions it can be safely disabled after adding the convenience symlinks to `.bazelignore`, for example:

--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
                     "default": false,
                     "markdownDescription": "Whether to add a CodeLens to `BUILD`/`BUILD.bazel` files to provide actions while browsing the file."
                 },
+                "bazel.enableQueries": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Whether to enable Bazel queries. When disabled, all query-dependent features (workspace tree, target completion, code lens, go-to-definition) will be disabled to improve performance and reduce Bazel server load."
+                },
                 "bazel.pathsToIgnore": {
                     "type": "array",
                     "items": {

--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -14,7 +14,10 @@
 
 import * as vscode from "vscode";
 
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import {
+  getDefaultBazelExecutablePath,
+  areBazelQueriesEnabled,
+} from "../extension/configuration";
 import { IBazelCommandAdapter, IBazelCommandOptions } from "./bazel_command";
 import { BazelQuery } from "./bazel_query";
 import { BazelWorkspaceInfo } from "./bazel_workspace_info";
@@ -97,6 +100,10 @@ export async function queryQuickPickTargets({
   query,
   workspaceInfo,
 }: QuickPickParams): Promise<BazelTargetQuickPick[]> {
+  if (!areBazelQueriesEnabled()) {
+    return [];
+  }
+
   if (workspaceInfo === undefined) {
     // Ask the user to pick a workspace, if we don't have one, yet
     workspaceInfo = await pickBazelWorkspace();
@@ -133,6 +140,10 @@ export async function queryQuickPickPackage({
   query,
   workspaceInfo,
 }: QuickPickParams): Promise<BazelTargetQuickPick[]> {
+  if (!areBazelQueriesEnabled()) {
+    return [];
+  }
+
   if (workspaceInfo === undefined) {
     // Ask the user to pick a workspace, if we don't have one, yet
     workspaceInfo = await pickBazelWorkspace();

--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -16,7 +16,10 @@ import * as vscode from "vscode";
 
 import { BazelWorkspaceInfo, QueryLocation } from "../bazel";
 import { getTargetsForBuildFile } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import {
+  getDefaultBazelExecutablePath,
+  areBazelQueriesEnabled,
+} from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { CodeLensCommandAdapter } from "./code_lens_command_adapter";
 
@@ -69,7 +72,10 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
     );
 
     vscode.workspace.onDidChangeConfiguration((change) => {
-      if (change.affectsConfiguration("bazel.enableCodeLens")) {
+      if (
+        change.affectsConfiguration("bazel.enableCodeLens") ||
+        change.affectsConfiguration("bazel.enableQueries")
+      ) {
         this.onDidChangeCodeLensesEmitter.fire();
       }
     });
@@ -88,6 +94,10 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
     const bazelConfig = vscode.workspace.getConfiguration("bazel");
     const enableCodeLens = bazelConfig.get<boolean>("enableCodeLens");
     if (!enableCodeLens) {
+      return [];
+    }
+
+    if (!areBazelQueriesEnabled()) {
       return [];
     }
 

--- a/src/definition/bazel_goto_definition_provider.ts
+++ b/src/definition/bazel_goto_definition_provider.ts
@@ -22,7 +22,10 @@ import {
 } from "vscode";
 import { Utils } from "vscode-uri";
 import { BazelQuery, BazelWorkspaceInfo, QueryLocation } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import {
+  getDefaultBazelExecutablePath,
+  areBazelQueriesEnabled,
+} from "../extension/configuration";
 import { blaze_query } from "../protos";
 
 // LABEL_REGEX matches label strings, e.g. @r//x/y/z:abc
@@ -32,6 +35,10 @@ export async function targetToUri(
   targetText: string,
   workingDirectory: Uri,
 ): Promise<QueryLocation | undefined> {
+  if (!areBazelQueriesEnabled()) {
+    return null;
+  }
+
   const match = LABEL_REGEX.exec(targetText);
 
   const targetName = match[1];

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -32,3 +32,13 @@ export function getDefaultBazelExecutablePath(): string {
   }
   return bazelExecutable;
 }
+
+/**
+ * Checks if Bazel queries are enabled in the workspace configuration.
+ *
+ * @returns True if Bazel queries are enabled (default), false otherwise.
+ */
+export function areBazelQueriesEnabled(): boolean {
+  const bazelConfig = vscode.workspace.getConfiguration("bazel");
+  return bazelConfig.get<boolean>("enableQueries", true);
+}

--- a/src/symbols/bazel_target_symbol_provider.ts
+++ b/src/symbols/bazel_target_symbol_provider.ts
@@ -17,7 +17,10 @@ import { DocumentSymbolProvider } from "vscode";
 
 import { BazelWorkspaceInfo, QueryLocation } from "../bazel";
 import { getTargetsForBuildFile } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import {
+  getDefaultBazelExecutablePath,
+  areBazelQueriesEnabled,
+} from "../extension/configuration";
 import { blaze_query } from "../protos";
 
 /** Provids Symbols for targets in Bazel BUILD files. */
@@ -25,6 +28,10 @@ export class BazelTargetSymbolProvider implements DocumentSymbolProvider {
   public async provideDocumentSymbols(
     document: vscode.TextDocument,
   ): Promise<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
+    if (!areBazelQueriesEnabled()) {
+      return [];
+    }
+
     const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
     if (workspaceInfo === undefined) {
       // Not in a Bazel Workspace.

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -19,7 +19,10 @@ import {
   IBazelCommandAdapter,
   IBazelCommandOptions,
 } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import {
+  getDefaultBazelExecutablePath,
+  areBazelQueriesEnabled,
+} from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
 import { IBazelTreeItem } from "./bazel_tree_item";
@@ -56,6 +59,11 @@ export class BazelPackageTreeItem
   }
 
   public async getChildren(): Promise<IBazelTreeItem[]> {
+    // If queries are disabled, just return subpackages
+    if (!areBazelQueriesEnabled()) {
+      return this.directSubpackages as IBazelTreeItem[];
+    }
+
     const queryResult = await new BazelQuery(
       getDefaultBazelExecutablePath(),
       this.workspaceInfo.bazelWorkspacePath,

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -14,7 +14,10 @@
 
 import * as vscode from "vscode";
 import { BazelWorkspaceInfo, BazelQuery } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import {
+  getDefaultBazelExecutablePath,
+  areBazelQueriesEnabled,
+} from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { BazelPackageTreeItem } from "./bazel_package_tree_item";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
@@ -150,6 +153,10 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
    * Returns a promise for an array of tree items representing build items.
    */
   private async getDirectoryItems(): Promise<IBazelTreeItem[]> {
+    if (!areBazelQueriesEnabled()) {
+      return Promise.resolve([] as IBazelTreeItem[]);
+    }
+
     // Retrieve the list of all packages underneath the current workspace
     // folder. Note that if the workspace folder is not the root of a Bazel
     // workspace but is instead a folder underneath it, we query for *only* the


### PR DESCRIPTION
Adds an option to fully disable queries to support large workspaces where performance is an issue.

In many cases when using this extension in large monorepos, the option to simply disable the functionality that depends on query while keeping basics like syntax highlighting is desireable; this allows the user to avoid accumulating many costly and long running queries that end up consuming 100% of their machine's resource until manually exited, without resorting to uninstalling the plugin.

Related to #227 