### PR TITLE
feat(navigation): add "Jump To Label" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This extension provides support for Bazel in Visual Studio.
 - **Bazel Task** definitions for `tasks.json`
 - **Coverage Support** showing coverage results from `bazel coverage` directly
   in VS Code.
-- **Code Navigation** to jump to BUILD files
+- **Code Navigation** to jump to BUILD files or labels
 - Debug Starlark code in your `.bzl` files during a build (set breakpoints, step
   through code, inspect variables, etc.)
 - URI handler to jump to targets from outside of VSCode. (Example: vscode://bazelbuild.vscode-bazel//path/to/tests:target)

--- a/package.json
+++ b/package.json
@@ -93,6 +93,11 @@
             },
             {
                 "category": "Bazel",
+                "command": "bazel.jumpToLabel",
+                "title": "Jump to Bazel Label"
+            },
+            {
+                "category": "Bazel",
                 "command": "bazel.refreshBazelBuildTargets",
                 "title": "Refresh Bazel Build Targets",
                 "icon": {
@@ -358,6 +363,10 @@
                 },
                 {
                     "command": "bazel.jumpToBuildFile",
+                    "when": "bazel.haveWorkspace"
+                },
+                {
+                    "command": "bazel.jumpToLabel",
                     "when": "bazel.haveWorkspace"
                 }
             ],

--- a/test/jump_to_label.test.ts
+++ b/test/jump_to_label.test.ts
@@ -1,0 +1,72 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import * as assert from "assert";
+
+// Simple mock that implements the required interface
+class MockTargetInfo {
+  constructor(
+    public rule: {
+      name: string;
+      location: string;
+    },
+  ) {}
+}
+
+function assertEditorIsActive(
+  expectedPath: string,
+  expectedLine: number,
+  expectedCharacter: number,
+) {
+  const activeEditor = vscode.window.activeTextEditor;
+  if (!activeEditor) {
+    throw new Error("No active editor found");
+  }
+  assert.strictEqual(activeEditor.document.uri.fsPath, expectedPath);
+
+  const position = activeEditor.selection.active;
+  assert.strictEqual(
+    position.line + 1,
+    expectedLine,
+    `Expected cursor to be on line ${expectedLine} but was on line ${position.line + 1}`,
+  );
+
+  assert.strictEqual(
+    position.character + 1,
+    expectedCharacter,
+    `Expected cursor to be at character ${expectedCharacter} but was at ${position.character + 1}`,
+  );
+}
+
+describe("Jump to Label", () => {
+  const workspacePath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "test",
+    "bazel_workspace",
+  );
+
+  beforeEach(async () => {
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  it("should jump to correct line in BUILD file", async () => {
+    // GIVEN
+    const targetLabel = "//pkg1:main";
+    const expectedFile = path.join(workspacePath, "pkg1", "BUILD");
+    const expectedLine = 1;
+    const expectedCharacter = 10;
+
+    // Mock the quick pick to return our target
+    const mockTargetInfo = new MockTargetInfo({
+      name: targetLabel,
+      location: `${expectedFile}:${expectedLine}:${expectedCharacter}`,
+    });
+
+    // WHEN
+    await vscode.commands.executeCommand("bazel.jumpToLabel", mockTargetInfo);
+
+    // THEN
+    assertEditorIsActive(expectedFile, expectedLine, expectedCharacter);
+  });
+});


### PR DESCRIPTION
This PR adds a new command `Jump To Label`, that allows users to quickly jump to the target declaration for a given label.

To implement this, the result of a `BazelQuery` is extended with the proto message that was returned from the subprocess call.

Part of #353.


BEGIN_COMMIT_OVERRIDE
feat(navigation): Add "Go to Label" command
END_COMMIT_OVERRIDE