### PR TITLE
feat(docs): add testing guidelines for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,14 @@ extensions to have these tools applied automatically as you develop:
 - [Prettier - Code Formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 
+## Testing
+
+We expect contributions to include tests that demonstrate and validate the intended behavior.
+
+- New features: add a set of VS Code integration tests that demo the intended behaviour by making use of the mock workspace under `test/bazel_workspace` (vscode-tests will be executed within this workspace). Integration tests should exercise the extension as a user would (for example: open editors, execute commands with `vscode.commands.executeCommand`, and assert on the editor state or extension outputs). See `test/go_to_label.test.ts` for a minimal integration-style example.
+
+- Utilities and bug fixes: extend the existing unit tests. If you add a new util or fix an existing one, include unit tests that cover the happy path and at least one edge case. See `test/code_lens_provider.test.ts` for a unit-style example.
+
 ## Commit messages
 
 Commit messages should follow the [Conventional Commit message](https://www.conventionalcommits.org/)


### PR DESCRIPTION
This PR extends the contribution guidelines to mention the necessity of tests for new contributions.

Closes #32

BEGIN_COMMIT_OVERRIDE
docs: add testing guidelines for contributions
END_COMMIT_OVERRIDE