### PR TITLE
fix(quickpick): Respect config settings for initial query scope.

### DIFF
--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -185,23 +185,23 @@ export async function queryQuickPickPackage({
  * Shows a QuickPick of Bazel labels that dynamically updates its items based on the user's input.
  *
  * Configuration options:
- * @param options.initialPattern Initial pattern to use (e.g., "//...")
  * @param options.queryBuilder Function that builds a Bazel query from a pattern (e.g. `pattern => "kind('.* rule', ${pattern})"`)
  * @param options.queryFunctor Function that executes the query and returns the quick pick items
  * @param options.workspaceInfo Workspace information for the Bazel project
  * @returns A promise that resolves with the selected BazelTargetQuickPick, or undefined if no selection was made
  */
 export function showDynamicQuickPick({
-  initialPattern,
   queryBuilder,
   queryFunctor,
   workspaceInfo,
 }: {
-  initialPattern: string;
   queryBuilder: (pattern: string) => string;
   queryFunctor: (params: QuickPickParams) => Promise<BazelTargetQuickPick[]>;
   workspaceInfo?: BazelWorkspaceInfo;
 }): Promise<BazelTargetQuickPick | undefined> {
+  const initialPattern: string = vscode.workspace
+    .getConfiguration("bazel.commandLine")
+    .get("queryExpression");
   const quickPick = vscode.window.createQuickPick<BazelTargetQuickPick>();
   quickPick.title = "Select a Bazel target";
   quickPick.placeholder = "Start typing to search for targets...";

--- a/src/extension/bazel_wrapper_commands.ts
+++ b/src/extension/bazel_wrapper_commands.ts
@@ -52,7 +52,6 @@ async function selectSingleTarget(
   // Use Case 1: Command palette without target (adapter undefined) → prompt user
   if (adapter === undefined) {
     const quickPick = await showDynamicQuickPick({
-      initialPattern: "//...",
       queryBuilder: (pattern) => quickPickQuery.replace("...", pattern),
       queryFunctor: queryQuickPickTargets,
       workspaceInfo: await BazelWorkspaceInfo.fromWorkspaceFolders(),
@@ -121,7 +120,6 @@ async function bazelBuildTargetWithDebugging(
     // invoked via the command palatte. Provide quickpick build targets for
     // the user to choose from.
     const quickPick = await showDynamicQuickPick({
-      initialPattern: "//...",
       queryBuilder: (pattern) => `kind('.* rule', ${pattern})`,
       queryFunctor: queryQuickPickTargets,
       workspaceInfo: await BazelWorkspaceInfo.fromWorkspaceFolders(),
@@ -189,7 +187,6 @@ async function buildPackage(
     // invoked via the command palatte. Provide quickpick build targets for
     // the user to choose from.
     const quickPick = await showDynamicQuickPick({
-      initialPattern: "//...",
       queryBuilder: (pattern) => pattern,
       queryFunctor: queryQuickPickPackage,
       workspaceInfo: await BazelWorkspaceInfo.fromWorkspaceFolders(),
@@ -299,7 +296,6 @@ async function testPackage(
     // invoked via the command palatte. Provide quickpick build targets for
     // the user to choose from.
     const quickPick = await showDynamicQuickPick({
-      initialPattern: "//...",
       queryBuilder: (pattern) => pattern,
       queryFunctor: queryQuickPickPackage,
       workspaceInfo: await BazelWorkspaceInfo.fromWorkspaceFolders(),
@@ -390,7 +386,6 @@ async function bazelGoToBuildFile() {
 async function bazelGoToLabel(target_info?: blaze_query.ITarget | undefined) {
   if (!target_info) {
     const quickPick = await showDynamicQuickPick({
-      initialPattern: "//...",
       queryBuilder: (pattern) => `kind('.* rule', ${pattern})`,
       queryFunctor: queryQuickPickTargets,
       workspaceInfo: await BazelWorkspaceInfo.fromWorkspaceFolders(),


### PR DESCRIPTION
While further browsing the source code, I realized that there is a user config for setting the inital scope of bazel queries. 
It's already beeing used for the `BazelWorkspaceTreeProvider` and will now also be used for `showDynamicQuickPick`.
