### PR TITLE
feat(navigation): Improve "Go to BUILD file" command

### DIFF
--- a/src/extension/bazel_wrapper_commands.ts
+++ b/src/extension/bazel_wrapper_commands.ts
@@ -22,6 +22,7 @@ import {
   getBazelPackageFile,
   getBazelWorkspaceFolder,
   getBazelPackageFolder,
+  getBuildFileLineWithSourceFilePath,
 } from "../bazel/bazel_utils";
 import {
   queryQuickPickTargets,
@@ -374,20 +375,17 @@ async function bazelGoToBuildFile() {
     vscode.Uri.file(buildFilePath),
   );
 
-  // Find the line number where the current file is referenced
-  const relativePath = path.relative(path.dirname(buildFilePath), filePath);
-  for (let i = 0; i < editor.document.lineCount; i++) {
-    if (editor.document.lineAt(i).text.includes(relativePath)) {
-      // Move cursor to the line with the reference it found
-      const position = new vscode.Position(i, 0);
-      editor.selection = new vscode.Selection(position, position);
-      editor.revealRange(
-        new vscode.Range(position, position),
-        vscode.TextEditorRevealType.InCenter,
-      );
-      break;
-    }
+  // Move cursor to the line with the reference it found
+  const line = getBuildFileLineWithSourceFilePath(buildFilePath, filePath);
+  if (line === undefined) {
+    return;
   }
+  const position = new vscode.Position(line, 0);
+  editor.selection = new vscode.Selection(position, position);
+  editor.revealRange(
+    new vscode.Range(position, position),
+    vscode.TextEditorRevealType.InCenter,
+  );
 }
 
 /**

--- a/test/go_to_build_file.test.ts
+++ b/test/go_to_build_file.test.ts
@@ -69,7 +69,7 @@ describe("Go to Build File", () => {
         "foobar.txt",
       ),
       expectedBuildFile: path.join(workspacePath, "pkg2", "sub-pkg", "BUILD"),
-      expectedLineNumber: 3, // line with srcs=["subfolder/foobar.txt"]
+      expectedLineNumber: 5, // line with srcs=["subfolder/foobar.txt"]
     },
     {
       name: "should not change active file if already at BUILD file",


### PR DESCRIPTION
The command will now attempt to jump to the correct line inside the build file, based on a simple search for a reference of the source file.

fixes #502 