### PR TITLE
build(CI): Reduce amount of triggered CI runs when working on forks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
   build_vscode_ext:
     name: Build VS Code extension
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'bazel-contrib/vscode-bazel' }} # Allow CI-runs only for events from/to this repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
The change will avoid triggering the CI pipelines when working on forks. This reduces noise and saves on resources, as typically there is no CI available in private forks anyway. PRs towards the main repository will still trigger a CI flow, as the repository providing the workflow definition will in this case still be the main repo.