### PR TITLE
Add bazel query options setting 

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
                     "default": "...:*",
                     "description": "A [query language expression](https://bazel.build/query/language) which determines the packages displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*`"
                 },
-                "bazel.queryPackagesOptions": {
+                "bazel.queryOptions.packages": {
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -204,6 +204,15 @@
                     "uniqueItems": true,
                     "default": [],
                     "markdownDescription": "A list of additional command line options to pass to `bazel query` when querying packages. Useful for scenarios like git sparse-checkout where `--keep_going` can help handle missing packages. One option per entry, no shell escaping is needed."
+                },
+                "bazel.queryOptions.targets": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": [],
+                    "markdownDescription": "A list of additional command line options to pass to `bazel query` when querying targets. Useful for scenarios like git sparse-checkout where `--keep_going` can help handle missing packages. One option per entry, no shell escaping is needed."
                 },
                 "bazel.lsp.command": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -196,6 +196,15 @@
                     "default": "...:*",
                     "description": "A [query language expression](https://bazel.build/query/language) which determines the packages displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*`"
                 },
+                "bazel.queryPackagesOptions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": [],
+                    "markdownDescription": "A list of additional command line options to pass to `bazel query` when querying packages. Useful for scenarios like git sparse-checkout where `--keep_going` can help handle missing packages. One option per entry, no shell escaping is needed."
+                },
                 "bazel.lsp.command": {
                     "type": "string",
                     "default": "",

--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -238,13 +238,13 @@ export class BazelQuery extends BazelCommand {
         // Handle exit code 3 with --keep_going as a partial success
         if (code === 3 && hasKeepGoing) {
           logWarn(
-            "Bazel query was partially successful (if you are using git " +
-              "sparse-checkout, this may be expected).",
+            "Bazel query was partially successful (`--keep_going` was used).",
             true,
             "Partial success, but the query encountered 1 or more errors " +
               "in the input BUILD file set and therefore the results of " +
               "the operation are not 100% reliable. This is likely due " +
-              "to a --keep_going option on the command line.",
+              "to a --keep_going option on the command line.  Full output: %s",
+            errorOutput,
           );
           resolve(Buffer.concat(chunks));
           return;

--- a/test/bazel_query.test.ts
+++ b/test/bazel_query.test.ts
@@ -1,0 +1,180 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+import { BazelQuery } from "../src/bazel/bazel_query";
+import { blaze_query } from "../src/protos";
+
+describe("BazelQuery", () => {
+  const workspacePath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "test",
+    "bazel_workspace",
+  );
+
+  async function setQueryOptionsConfig(
+    packages?: string[],
+    targets?: string[],
+  ): Promise<void> {
+    const config = vscode.workspace.getConfiguration("bazel");
+    if (packages !== undefined) {
+      await config.update("queryOptions.packages", packages);
+    }
+    if (targets !== undefined) {
+      await config.update("queryOptions.targets", targets);
+    }
+  }
+
+  beforeEach(async () => {
+    // Reset config before each test
+    await setQueryOptionsConfig([], []);
+  });
+
+  afterEach(async () => {
+    // Reset config after each test
+    await setQueryOptionsConfig([], []);
+  });
+
+  describe("queryTargets", () => {
+    it("should merge config options with additionalOptions", async function () {
+      this.timeout(10000);
+      await setQueryOptionsConfig(undefined, ["--keep_going"]);
+
+      const query = new BazelQuery("bazel", workspacePath);
+      let capturedOptions: string[] = [];
+
+      // Mock the run method to capture options
+      // @ts-expect-error - accessing protected method for testing
+      const originalRun = query.run.bind(query);
+      // @ts-expect-error - accessing protected method for testing
+      query.run = async (options: string[]) => {
+        capturedOptions = options;
+        // Return a minimal valid QueryResult proto
+        const result = blaze_query.QueryResult.create({
+          target: [],
+        });
+        return Buffer.from(blaze_query.QueryResult.encode(result).finish());
+      };
+
+      await query.queryTargets("//...", {
+        additionalOptions: ["--output=json"],
+      });
+
+      // Verify config options come before additionalOptions
+      const queryIndex = capturedOptions.indexOf("//...");
+      const keepGoingIndex = capturedOptions.indexOf("--keep_going");
+      const outputJsonIndex = capturedOptions.indexOf("--output=json");
+
+      assert.ok(queryIndex >= 0, "Query should be in options");
+      assert.ok(keepGoingIndex >= 0, "Config option should be in options");
+      assert.ok(outputJsonIndex >= 0, "Additional option should be in options");
+      assert.ok(
+        keepGoingIndex < outputJsonIndex,
+        "Config options should come before additionalOptions",
+      );
+    });
+
+    it("should use empty array when config is not set", async function () {
+      this.timeout(10000);
+      await setQueryOptionsConfig(undefined, []);
+
+      const query = new BazelQuery("bazel", workspacePath);
+      let capturedOptions: string[] = [];
+
+      // @ts-expect-error - accessing protected method for testing
+      const originalRun = query.run.bind(query);
+      // @ts-expect-error - accessing protected method for testing
+      query.run = async (options: string[]) => {
+        capturedOptions = options;
+        const result = blaze_query.QueryResult.create({
+          target: [],
+        });
+        return Buffer.from(blaze_query.QueryResult.encode(result).finish());
+      };
+
+      await query.queryTargets("//...", {
+        additionalOptions: ["--output=json"],
+      });
+
+      // Verify only additionalOptions are present (no config options)
+      const keepGoingIndex = capturedOptions.indexOf("--keep_going");
+      const outputJsonIndex = capturedOptions.indexOf("--output=json");
+
+      assert.strictEqual(
+        keepGoingIndex,
+        -1,
+        "Config option should not be present",
+      );
+      assert.ok(outputJsonIndex >= 0, "Additional option should be present");
+    });
+  });
+
+  describe("queryPackages", () => {
+    it("should merge config options with additionalOptions", async function () {
+      this.timeout(10000);
+      await setQueryOptionsConfig(["--keep_going"], undefined);
+
+      const query = new BazelQuery("bazel", workspacePath);
+      let capturedOptions: string[] = [];
+
+      // Mock the run method to capture options
+      // @ts-expect-error - accessing protected method for testing
+      const originalRun = query.run.bind(query);
+      // @ts-expect-error - accessing protected method for testing
+      query.run = async (options: string[]) => {
+        capturedOptions = options;
+        // Return empty result
+        return Buffer.from("");
+      };
+
+      await query.queryPackages("//...", {
+        additionalOptions: ["--output=json"],
+      });
+
+      // Verify config options come before additionalOptions
+      const queryIndex = capturedOptions.indexOf("//...");
+      const keepGoingIndex = capturedOptions.indexOf("--keep_going");
+      const outputJsonIndex = capturedOptions.indexOf("--output=json");
+
+      assert.ok(queryIndex >= 0, "Query should be in options");
+      assert.ok(keepGoingIndex >= 0, "Config option should be in options");
+      assert.ok(outputJsonIndex >= 0, "Additional option should be in options");
+      assert.ok(
+        keepGoingIndex < outputJsonIndex,
+        "Config options should come before additionalOptions",
+      );
+    });
+
+    it("should use empty array when config is not set", async function () {
+      this.timeout(10000);
+      await setQueryOptionsConfig([], undefined);
+
+      const query = new BazelQuery("bazel", workspacePath);
+      let capturedOptions: string[] = [];
+
+      // @ts-expect-error - accessing protected method for testing
+      const originalRun = query.run.bind(query);
+      // @ts-expect-error - accessing protected method for testing
+      query.run = async (options: string[]) => {
+        capturedOptions = options;
+        return Buffer.from("");
+      };
+
+      await query.queryPackages("//...", {
+        additionalOptions: ["--output=json"],
+      });
+
+      // Verify only additionalOptions are present (no config options)
+      const keepGoingIndex = capturedOptions.indexOf("--keep_going");
+      const outputJsonIndex = capturedOptions.indexOf("--output=json");
+
+      assert.strictEqual(
+        keepGoingIndex,
+        -1,
+        "Config option should not be present",
+      );
+      assert.ok(outputJsonIndex >= 0, "Additional option should be present");
+    });
+  });
+});


### PR DESCRIPTION
## Description
For very large bazel repos, [git sparse checkout](https://git-scm.com/docs/git-sparse-checkout) is commonly used to only pull a subset of directories in a repo.  When this happens, the local version of the repo may not have all of the dependencies of all packages or tools required and this is expected.

Because the current `bazel query` call on extension startup passes `...:*` as the default query, the extension will automatically try to query all packages and will fail if any are missing, and will infinitely re-query and fail.  This can be resolved by adding `--keep_going` to the query command.

This PR adds a `bazel query packages options` setting to allow users to append custom parameters to the bazel query to support things such as sparse checkout.

## Related Issue
#198 

## Testing
- [x] Tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Code follows the project's style guidelines (prettier/eslint)
- [x] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [x] Tests pass locally (`npm run test`)



