### PR TITLE
chore: Fix unit tests

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -7,4 +7,5 @@ module.exports = defineConfig({
     timeout: 5000,
   },
   workspaceFolder: "test/bazel_workspace",
+  version: "1.111.0",
 });

--- a/test/buildifier.test.ts
+++ b/test/buildifier.test.ts
@@ -52,13 +52,13 @@ describe("buildifier", () => {
         code: "unused-variable",
         message: 'Variable "_foo" is unused. Please remove it.',
         range: {
-          a: {
-            a: 1,
-            b: 0,
+          _start: {
+            _line: 1,
+            _character: 0,
           },
-          b: {
-            a: 1,
-            b: 4,
+          _end: {
+            _line: 1,
+            _character: 4,
           },
         },
         severity: 1,


### PR DESCRIPTION
Since we were using the latest stable version of vscode, the tests broke without any code changes. This updates the tests and pins the vscode version to the latest stable, to make CI reproducible.