### PR TITLE
deps: update serialize-javascript to 7.0.3 to resolve GHSA-5c6j-r48x-rmvq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,7 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
             "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
@@ -1048,6 +1049,7 @@
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
             "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -1057,21 +1059,24 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1206,10 +1211,11 @@
             }
         },
         "node_modules/@secretlint/config-loader/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -1481,7 +1487,8 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
             "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -1822,6 +1829,7 @@
             "resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.12.tgz",
             "integrity": "sha512-iYN0fDg29+a2Xelle/Y56Xvv7Nc8Thzq4VwpzAF/SIE6918rDicqfsQxV6w1ttr2+SOm+10laGuY9FG2ptEKsQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^10.0.10",
                 "c8": "^10.1.3",
@@ -1889,6 +1897,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
             "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -2501,6 +2510,7 @@
             "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
             "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.1",
                 "@istanbuljs/schema": "^0.1.3",
@@ -2787,7 +2797,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -3977,7 +3988,8 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/htmlparser2": {
             "version": "8.0.2",
@@ -4243,6 +4255,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
             "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=8"
             }
@@ -4252,6 +4265,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
             "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
                 "make-dir": "^4.0.0",
@@ -4266,6 +4280,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -4274,10 +4289,11 @@
             }
         },
         "node_modules/istanbul-reports": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
@@ -4637,6 +4653,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
             "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "semver": "^7.5.3"
             },
@@ -4648,10 +4665,11 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -5616,16 +5634,6 @@
                 }
             ]
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5870,13 +5878,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+            "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/setimmediate": {
@@ -6280,10 +6288,11 @@
             }
         },
         "node_modules/table/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6372,33 +6381,50 @@
             }
         },
         "node_modules/test-exclude": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+            "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^10.4.1",
-                "minimatch": "^9.0.4"
+                "minimatch": "^10.2.2"
             },
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+        "node_modules/test-exclude/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/test-exclude/node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/test-exclude/node_modules/glob": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -6414,16 +6440,50 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/test-exclude/node_modules/minimatch": {
+        "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
             "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/minimatch": {
+            "version": "10.2.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -6615,10 +6675,11 @@
             "dev": true
         },
         "node_modules/underscore": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
-            "dev": true
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/undici-types": {
             "version": "7.16.0",
@@ -6677,10 +6738,11 @@
             }
         },
         "node_modules/v8-to-istanbul": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -6858,10 +6920,11 @@
             }
         },
         "node_modules/vscode-tmgrammar-test/node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -7676,15 +7739,15 @@
             "dev": true
         },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -7802,9 +7865,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.17.1",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-                    "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+                    "version": "8.18.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+                    "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
@@ -9970,9 +10033,9 @@
             }
         },
         "istanbul-reports": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
             "dev": true,
             "requires": {
                 "html-escaper": "^2.0.0",
@@ -10286,9 +10349,9 @@
             }
         },
         "markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1",
@@ -10410,7 +10473,7 @@
                 "minimatch": "^9.0.5",
                 "ms": "^2.1.3",
                 "picocolors": "^1.1.1",
-                "serialize-javascript": "^6.0.2",
+                "serialize-javascript": "7.0.3",
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
                 "workerpool": "^9.2.0",
@@ -10977,15 +11040,6 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
-        "randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -11156,13 +11210,10 @@
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
         },
         "serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "requires": {
-                "randombytes": "^2.1.0"
-            }
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+            "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+            "dev": true
         },
         "setimmediate": {
             "version": "1.0.5",
@@ -11447,9 +11498,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.17.1",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-                    "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+                    "version": "8.18.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+                    "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
@@ -11524,23 +11575,29 @@
             }
         },
         "test-exclude": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+            "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
             "dev": true,
             "requires": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^10.4.1",
-                "minimatch": "^9.0.4"
+                "minimatch": "^10.2.2"
             },
             "dependencies": {
+                "balanced-match": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+                    "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+                    "dev": true
+                },
                 "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                    "version": "5.0.5",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+                    "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0"
+                        "balanced-match": "^4.0.2"
                     }
                 },
                 "glob": {
@@ -11555,15 +11612,41 @@
                         "minipass": "^7.1.2",
                         "package-json-from-dist": "^1.0.0",
                         "path-scurry": "^1.11.1"
+                    },
+                    "dependencies": {
+                        "balanced-match": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+                            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+                            "dev": true
+                        },
+                        "brace-expansion": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+                            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                            "dev": true,
+                            "requires": {
+                                "balanced-match": "^1.0.0"
+                            }
+                        },
+                        "minimatch": {
+                            "version": "9.0.9",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+                            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^2.0.2"
+                            }
+                        }
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.9",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-                    "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+                    "version": "10.2.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+                    "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^2.0.2"
+                        "brace-expansion": "^5.0.2"
                     }
                 }
             }
@@ -11695,9 +11778,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true
         },
         "undici-types": {
@@ -11745,9 +11828,9 @@
             "dev": true
         },
         "v8-to-istanbul": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
             "dev": true,
             "requires": {
                 "@jridgewell/trace-mapping": "^0.3.12",
@@ -11899,9 +11982,9 @@
                     "dev": true
                 },
                 "diff": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+                    "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
                     "dev": true
                 },
                 "escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -541,6 +541,9 @@
         "typescript": "^5.4.4",
         "vscode-tmgrammar-test": "^0.1.3"
     },
+    "overrides": {
+        "serialize-javascript": "7.0.3"
+    },
     "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",


### PR DESCRIPTION
## Description

- Add overrides to force serialize-javascript@7.0.3 for all dependencies
- Removes vulnerability to code injection via RegExp.flags and Date.prototype.toISOString()

## Related Issue

https://github.com/bazel-contrib/vscode-bazel/security/dependabot/51

## Testing

<!-- Describe how you tested your changes -->

- [ ] Tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Code follows the project's style guidelines (prettier/eslint)
- [ ] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [ ] Tests pass locally (`npm run test`)
