### PR TITLE
refactor: Introduce extension feature base class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "@eslint/js": "^10.0.0",
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^24.5.2",
+                "@types/sinon": "^21.0.0",
                 "@types/vscode": "^1.88.0",
                 "@types/which": "^3.0.3",
                 "@typescript-eslint/eslint-plugin": "^8.44.1",
@@ -35,6 +36,7 @@
                 "js-yaml": "^4.1.1",
                 "mocha": "^11.0.0",
                 "prettier": "^3.2.5",
+                "sinon": "^21.0.3",
                 "typescript": "^5.4.4",
                 "vscode-tmgrammar-test": "^0.1.3"
             },
@@ -1410,6 +1412,47 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@sinonjs/commons": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+            "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/@sinonjs/samsam": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-9.0.3.tgz",
+            "integrity": "sha512-ZgYY7Dc2RW+OUdnZ1DEHg00lhRt+9BjymPKHog4PRFzr1U3MbK57+djmscWyKxzO1qfunHqs4N45WWyKIFKpiQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "type-detect": "^4.1.0"
+            }
+        },
+        "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/@textlint/ast-node-types": {
             "version": "15.5.0",
             "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.0.tgz",
@@ -1520,6 +1563,23 @@
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
             "dev": true
         },
+        "node_modules/@types/sinon": {
+            "version": "21.0.0",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
+            "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/sinonjs__fake-timers": "*"
+            }
+        },
+        "node_modules/@types/sinonjs__fake-timers": {
+            "version": "15.0.1",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+            "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/vscode": {
             "version": "1.110.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
@@ -1574,6 +1634,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
             "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.2",
                 "@typescript-eslint/types": "8.57.2",
@@ -2197,6 +2258,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3221,6 +3283,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
             "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -6037,6 +6100,47 @@
                 "simple-concat": "^1.0.0"
             }
         },
+        "node_modules/sinon": {
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.3.tgz",
+            "integrity": "sha512-0x8TQFr8EjADhSME01u1ZK31yv2+bd6Z5NrBCHVM+n4qL1wFqbxftmeyi3bwlr49FbbzRfrqSFOpyHCOh/YmYA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^15.1.1",
+                "@sinonjs/samsam": "^9.0.3",
+                "diff": "^8.0.3",
+                "supports-color": "^7.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
+        "node_modules/sinon/node_modules/diff": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/sinon/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/slash": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -6488,6 +6592,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6584,6 +6689,16 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/typed-rest-client": {
             "version": "1.8.11",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
@@ -6600,6 +6715,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
             "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7955,6 +8071,42 @@
             "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
             "dev": true
         },
+        "@sinonjs/commons": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+            "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-9.0.3.tgz",
+            "integrity": "sha512-ZgYY7Dc2RW+OUdnZ1DEHg00lhRt+9BjymPKHog4PRFzr1U3MbK57+djmscWyKxzO1qfunHqs4N45WWyKIFKpiQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^3.0.1",
+                "type-detect": "^4.1.0"
+            },
+            "dependencies": {
+                "type-detect": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+                    "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+                    "dev": true
+                }
+            }
+        },
         "@textlint/ast-node-types": {
             "version": "15.5.0",
             "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.0.tgz",
@@ -8067,6 +8219,21 @@
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
             "dev": true
         },
+        "@types/sinon": {
+            "version": "21.0.0",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
+            "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
+            "dev": true,
+            "requires": {
+                "@types/sinonjs__fake-timers": "*"
+            }
+        },
+        "@types/sinonjs__fake-timers": {
+            "version": "15.0.1",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+            "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+            "dev": true
+        },
         "@types/vscode": {
             "version": "1.110.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
@@ -8108,6 +8275,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
             "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "8.57.2",
                 "@typescript-eslint/types": "8.57.2",
@@ -8508,7 +8676,8 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
@@ -9241,6 +9410,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
             "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -11258,6 +11428,36 @@
                 "simple-concat": "^1.0.0"
             }
         },
+        "sinon": {
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.3.tgz",
+            "integrity": "sha512-0x8TQFr8EjADhSME01u1ZK31yv2+bd6Z5NrBCHVM+n4qL1wFqbxftmeyi3bwlr49FbbzRfrqSFOpyHCOh/YmYA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^15.1.1",
+                "@sinonjs/samsam": "^9.0.3",
+                "diff": "^8.0.3",
+                "supports-color": "^7.2.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "8.0.4",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+                    "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "slash": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -11604,7 +11804,8 @@
                     "version": "4.0.4",
                     "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
                     "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -11671,6 +11872,12 @@
                 "prelude-ls": "^1.2.1"
             }
         },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
+        },
         "typed-rest-client": {
             "version": "1.8.11",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
@@ -11686,7 +11893,8 @@
             "version": "5.4.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
             "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "uc.micro": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -527,6 +527,7 @@
         "@eslint/js": "^10.0.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^24.5.2",
+        "@types/sinon": "^21.0.0",
         "@types/vscode": "^1.88.0",
         "@types/which": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^8.44.1",
@@ -542,6 +543,7 @@
         "js-yaml": "^4.1.1",
         "mocha": "^11.0.0",
         "prettier": "^3.2.5",
+        "sinon": "^21.0.3",
         "typescript": "^5.4.4",
         "vscode-tmgrammar-test": "^0.1.3"
     },

--- a/src/extension/extension_feature.ts
+++ b/src/extension/extension_feature.ts
@@ -1,0 +1,186 @@
+import * as vscode from "vscode";
+import { logInfo, logWarn, logError, showUserMessage } from "./logger";
+
+/**
+ * Represents a feature of the Bazel extension.
+ * A feature is a discrete piece of functionality that can be enabled/disabled.
+ *
+ * This base class enforces a common design to how this toggle mechanism is implemented:
+ * - A feature instance is created during the extensions activate() method
+ * - A feature instance is disposed of when the extension is disposed of or deactivated
+ * - A feature can be toggled on/off by toggling its configKey.
+ * - Toggling can be done multiple times and takes effect immediately, without reload.
+ * - Upon disabling, a feature disposes of all it's internal resources
+ * - Upon enabling, a feature recreates it's internal resources
+ * - Upon enabling, a feature checks it's required constraints and signals success or failure.
+ * - A named logger is used to log messages to the output pane.
+ *
+ * To comply with the design, a feature must:
+ * - have a unique `featureName`
+ * - have a corresponding config for enabling: `bazel.enable<featureName>`
+ * - have a corresponding context key to communicate its current state: `bazel.feature.<featureName>.enabled`
+ */
+export abstract class BaseExtensionFeature implements vscode.Disposable {
+  /**
+   * Name of the feature, used in settings.
+   */
+  readonly featureName: string;
+  private readonly configKey: string;
+  private readonly contextKey: string;
+
+  /**
+   * Whether the feature is currently enabled.
+   */
+  private isEnabled: boolean = false;
+
+  /**
+   * List of disposables registered by the feature.
+   * These will be disposed when the feature is disabled.
+   * Array can be refilled when feature is activated again.
+   */
+  protected disposables: vscode.Disposable[] = [];
+
+  /**
+   * Disposable for the onDidChangeConfiguration callback.
+   * It is stored seperately from the features _disposables,
+   * as it needs to live longer then the disable() call to assure that a feature can be turned on again.
+   */
+  private configCallback: vscode.Disposable;
+
+  /**
+   * The extension context. Will be handed to enable() method when toggled.
+   */
+  private context: vscode.ExtensionContext;
+
+  /**
+   * Creates a new feature instance.
+   * @param featureName The name of the feature.
+   * @param context The extension context.
+   * @param logger The logger instance.
+   */
+  constructor(featureName: string, context: vscode.ExtensionContext) {
+    this.featureName = featureName;
+    this.configKey = `bazel.enable${featureName}`;
+    this.contextKey = `bazel.feature.${featureName}.enabled`;
+    this.context = context;
+
+    // Register configuration change listener
+    this.configCallback = vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration(this.configKey)) {
+        this.onConfigurationChanged(vscode.workspace.getConfiguration());
+      }
+    });
+  }
+
+  /**
+   * Static Factory pattern for creating and ensuring a subsequent call for initialization.
+   * The feature will be initialized based on the current configuration.
+   */
+  static create<T extends BaseExtensionFeature>(
+    this: new (context: vscode.ExtensionContext) => T,
+    context: vscode.ExtensionContext,
+  ): T {
+    const instance = new this(context);
+    // Enable/Disable feature based on current configuration
+    instance.onConfigurationChanged(vscode.workspace.getConfiguration());
+    return instance;
+  }
+
+  /**
+   * Called when the feature's configuration changes.
+   * Calls enable or disable as required by config change.
+   * Keeps the context key in sync with the feature state.
+   * Logs erros in case of a activation failure.
+   * @param config The new configuration for the feature.
+   */
+  private onConfigurationChanged(config: vscode.WorkspaceConfiguration): void {
+    const shouldBeEnabled = this.isEnabledInConfig(config);
+    if (shouldBeEnabled && !this.isEnabled) {
+      this.logInfo(`Enabling ${this.constructor.name}`);
+      if (!this.enable(this.context)) {
+        void showUserMessage(
+          `Failed to enable ${this.constructor.name}`,
+          vscode.LogLevel.Error,
+          true,
+        );
+        return;
+      }
+      this.isEnabled = true;
+    } else if (!shouldBeEnabled && this.isEnabled) {
+      this.logInfo(`Disabling ${this.constructor.name}`);
+      if (!this.disable()) {
+        this.logError(`Failed to disable ${this.constructor.name}`);
+        return;
+      }
+      this.isEnabled = false;
+    }
+    vscode.commands.executeCommand(
+      "setContext",
+      this.contextKey,
+      this.isEnabled,
+    );
+  }
+
+  /**
+   * Returns true if the feature is enabled in the current configuration
+   * @param config The configuration to check
+   */
+  private isEnabledInConfig(config: vscode.WorkspaceConfiguration): boolean {
+    return config.get<boolean>(this.configKey);
+  }
+
+  /**
+   * Called when the feature is enabled
+   * @param context The extension context for registering disposables.
+   *
+   * Derived classes must implement this method. It shall:
+   * - check required preconditions and return false if not all are met and the feature can not be activated
+   * - create any required resources and add disposables to the `this.disposables` array.
+   * - return true after successfull enabling of the functionality
+   */
+  protected abstract enable(context: vscode.ExtensionContext): boolean;
+
+  /**
+   * Called when the feature is disabled.
+   * Should clean up any resources used by the feature, in a way that is safe to call multiple times.
+   */
+  protected disable(): boolean {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+    return true;
+  }
+
+  /**
+   * Internal helpers to prepend featureName to log messages.
+   */
+  protected logInfo(
+    message: string,
+    showMessage: boolean = false,
+    ...args: unknown[]
+  ): void {
+    logInfo(`[${this.featureName}] ${message}`, showMessage, ...args);
+  }
+  protected logWarn(
+    message: string,
+    showMessage: boolean = false,
+    ...args: unknown[]
+  ): void {
+    logWarn(`[${this.featureName}] ${message}`, showMessage, ...args);
+  }
+  protected logError(
+    message: string,
+    showMessage: boolean = false,
+    ...args: unknown[]
+  ): void {
+    logError(`[${this.featureName}] ${message}`, showMessage, ...args);
+  }
+
+  /**
+   * Called when the extension is deactivated.
+   * Cleanup and dispose all registered disposables, instance is unusable after.
+   */
+  dispose() {
+    this.disable();
+    this.configCallback.dispose();
+  }
+}

--- a/test/extension_feature.test.ts
+++ b/test/extension_feature.test.ts
@@ -1,0 +1,170 @@
+import * as vscode from "vscode";
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { BaseExtensionFeature } from "../src/extension/extension_feature";
+
+class TestExtensionFeature extends BaseExtensionFeature {
+  constructor(context: vscode.ExtensionContext) {
+    super("TestFeature", context);
+  }
+
+  protected enable(context: vscode.ExtensionContext): boolean {
+    this.disposables.push({
+      dispose: () => {
+        /* empty */
+      },
+    } as vscode.Disposable);
+    return true;
+  }
+}
+
+class FailingTestFeature extends BaseExtensionFeature {
+  constructor(context: vscode.ExtensionContext) {
+    super("FailingTestFeature", context);
+  }
+
+  protected enable(context: vscode.ExtensionContext): boolean {
+    return false;
+  }
+}
+
+describe("BaseExtensionFeature", () => {
+  let testFeature: TestExtensionFeature;
+  let failingFeature: FailingTestFeature;
+  let sandbox: sinon.SinonSandbox;
+  let mockContext: vscode.ExtensionContext;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    mockContext = {
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+    testFeature = new TestExtensionFeature(mockContext);
+    failingFeature = new FailingTestFeature(mockContext);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("create", () => {
+    it("creates and initializes the feature", () => {
+      const configStub = sandbox
+        .stub(vscode.workspace, "getConfiguration")
+        .returns({
+          get: sinon.stub().withArgs("bazel.enableTestFeature").returns(true),
+        } as any);
+      const setContextStub = sandbox.stub(vscode.commands, "executeCommand");
+
+      const feature = TestExtensionFeature.create(mockContext);
+
+      sinon.assert.calledOnce(configStub);
+      assert.ok((feature as any).disposables.length > 0);
+      sinon.assert.calledWith(
+        setContextStub,
+        "setContext",
+        "bazel.feature.TestFeature.enabled",
+        true,
+      );
+    });
+  });
+
+  describe("onConfigurationChanged", () => {
+    it("enables when config is true and not enabled", () => {
+      const config = {
+        get: sinon.stub().withArgs("bazel.enableTestFeature").returns(true),
+      } as any;
+      const setContextStub = sandbox.stub(vscode.commands, "executeCommand");
+
+      (testFeature as any).onConfigurationChanged(config);
+
+      assert.strictEqual((testFeature as any).isEnabled, true);
+      assert.ok((testFeature as any).disposables.length > 0);
+      sinon.assert.calledWith(
+        setContextStub,
+        "setContext",
+        "bazel.feature.TestFeature.enabled",
+        true,
+      );
+    });
+
+    it("disables when config is false and enabled", () => {
+      // First enable
+      const configTrue = {
+        get: sinon.stub().withArgs("bazel.enableTestFeature").returns(true),
+      } as any;
+      (testFeature as any).onConfigurationChanged(configTrue);
+      assert.strictEqual((testFeature as any).isEnabled, true);
+
+      // Then disable
+      const configFalse = {
+        get: sinon.stub().withArgs("bazel.enableTestFeature").returns(false),
+      } as any;
+      const setContextStub = sandbox.stub(vscode.commands, "executeCommand");
+      (testFeature as any).onConfigurationChanged(configFalse);
+
+      assert.strictEqual((testFeature as any).isEnabled, false);
+      assert.strictEqual((testFeature as any).disposables.length, 0);
+      sinon.assert.calledWith(
+        setContextStub,
+        "setContext",
+        "bazel.feature.TestFeature.enabled",
+        false,
+      );
+    });
+
+    it("does not enable if enable returns false", () => {
+      const config = {
+        get: sinon
+          .stub()
+          .withArgs("bazel.enableFailingTestFeature")
+          .returns(true),
+      } as any;
+      const showMessageStub = sandbox
+        .stub(vscode.window, "showErrorMessage")
+        .resolves();
+
+      (failingFeature as any).onConfigurationChanged(config);
+
+      assert.strictEqual((failingFeature as any).isEnabled, false);
+      sinon.assert.calledWith(
+        showMessageStub,
+        "Failed to enable FailingTestFeature",
+      );
+    });
+  });
+
+  describe("disable", () => {
+    it("disposes all disposables", () => {
+      // Enable first
+      const config = {
+        get: sinon.stub().withArgs("bazel.enableTestFeature").returns(true),
+      } as any;
+      (testFeature as any).onConfigurationChanged(config);
+      assert.ok((testFeature as any).disposables.length > 0);
+
+      const disposeSpy = sandbox.spy(
+        (testFeature as any).disposables[0],
+        "dispose",
+      );
+
+      (testFeature as any).disable();
+
+      sinon.assert.calledOnce(disposeSpy);
+      assert.strictEqual((testFeature as any).disposables.length, 0);
+    });
+  });
+
+  describe("dispose", () => {
+    it("disables and disposes config callback", () => {
+      const configCallbackDisposeSpy = sandbox.spy(
+        (testFeature as any).configCallback,
+        "dispose",
+      );
+
+      testFeature.dispose();
+
+      sinon.assert.calledOnce(configCallbackDisposeSpy);
+    });
+  });
+});


### PR DESCRIPTION
## Description

This is a breakout of #496 and introduces the base class only. This class holds the core idea and design of the proposed "Extension Features", which will allow for refactoring the extension in a way, that each of the contained features can be activated or deactivated on its own, at runtime and in isolation of the other features.

Deactivation of individual features has been a much requested improvement to this VSCode extension, as some of the features can be resource intensive in big repositories which is annoying if the features themselves are not even used by the user. E.g. if you are only interested in syntax highlighting but do not want VSCode to run bazel queries in the background.

The benefit that I see in creating the base class first is that it can define a clear design of how this functionality is to be introduced in the code place and it allows to handle some base logic in a common single place. I.e.: Reacting to configuration changes, managing resource lifetime, logging, checking preconditions and failing safely. See comments in source code for more infos.

## Related Issue

#490 

## Testing

<!-- Describe how you tested your changes -->

- [x] Tests added/updated -> See #496  for example tests
- [ ] Manual testing performed

## Checklist

- [x] Code follows the project's style guidelines (prettier/eslint)
- [x] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [x] Tests pass locally (`npm run test`)
