### PR TITLE
feat(completion): add queryScope config to scope completion target query

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,14 @@
                     "default": "...:*",
                     "description": "A [query language expression](https://bazel.build/query/language) which determines the packages displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*`"
                 },
+                "bazel.completion.queryScope": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "A list of Bazel package patterns to scope the completion provider's target query. When empty (default), the entire workspace (`...`) is queried. Specify patterns like `//src/...`, `//lib/...` to limit the query to specific directories. For example: `[\"//src/...\", \"//lib/...\"]`."
+                },
                 "bazel.lsp.command": {
                     "type": "string",
                     "default": "",

--- a/src/completion-provider/bazel_completion_provider.ts
+++ b/src/completion-provider/bazel_completion_provider.ts
@@ -18,6 +18,7 @@ import {
   getPackageLabelForBuildFile,
   queryQuickPickTargets,
 } from "../bazel";
+import { getCompletionQueryScope } from "../extension/configuration";
 
 function insertCompletionItemIfUnique(
   options: vscode.CompletionItem[],
@@ -139,12 +140,26 @@ export class BazelCompletionItemProvider
   }
 
   /**
+   * Builds a Bazel query expression for fetching rule targets.
+   *
+   * When {@link getCompletionQueryScope} returns a non-empty list of patterns
+   * (e.g. `["//src/...", "//lib/..."]`), the query is scoped to those
+   * directories via `kind('.* rule', //src/... + //lib/...)`.
+   * Otherwise the entire workspace is queried (`kind('.* rule', ...)`).
+   */
+  private buildQuery(): string {
+    const scope = getCompletionQueryScope();
+    const scopeExpr = scope.length > 0 ? scope.join(" + ") : "...";
+    return `kind('.* rule', ${scopeExpr})`;
+  }
+
+  /**
    * Runs a bazel query command to acquire labels of all the targets in the
-   * workspace.
+   * workspace (or a configured subset of it).
    */
   public async refresh() {
     const queryTargets = await queryQuickPickTargets({
-      query: "kind('.* rule', ...)",
+      query: this.buildQuery(),
     });
     if (queryTargets.length !== 0) {
       this.targets = queryTargets.map((queryTarget) => {

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -73,3 +73,15 @@ export function getQueryExpression(): string {
     "queryExpression",
   );
 }
+
+/**
+ * Gets the list of Bazel package patterns used to scope the completion
+ * provider's target query. An empty array means the entire workspace is
+ * queried.
+ */
+export function getCompletionQueryScope(): string[] {
+  return getConfigurationWithDefault<string[]>(
+    "bazel.completion",
+    "queryScope",
+  );
+}

--- a/test/bazel_completion_provider.test.ts
+++ b/test/bazel_completion_provider.test.ts
@@ -1,0 +1,45 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { BazelCompletionItemProvider } from "../src/completion-provider/bazel_completion_provider";
+
+describe("BazelCompletionItemProvider", () => {
+  describe("buildQuery", () => {
+    afterEach(async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.completion")
+        .update("queryScope", undefined, vscode.ConfigurationTarget.Workspace);
+    });
+
+    it("should query entire workspace when queryScope is empty", () => {
+      const provider = new BazelCompletionItemProvider();
+      const query = (provider as any).buildQuery();
+      assert.strictEqual(query, "kind('.* rule', ...)");
+    });
+
+    it("should scope query to single pattern when queryScope has one entry", async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.completion")
+        .update(
+          "queryScope",
+          ["//src/..."],
+          vscode.ConfigurationTarget.Workspace,
+        );
+      const provider = new BazelCompletionItemProvider();
+      const query = (provider as any).buildQuery();
+      assert.strictEqual(query, "kind('.* rule', //src/...)");
+    });
+
+    it("should join multiple patterns with ' + ' when queryScope has multiple entries", async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.completion")
+        .update(
+          "queryScope",
+          ["//src/...", "//lib/..."],
+          vscode.ConfigurationTarget.Workspace,
+        );
+      const provider = new BazelCompletionItemProvider();
+      const query = (provider as any).buildQuery();
+      assert.strictEqual(query, "kind('.* rule', //src/... + //lib/...)");
+    });
+  });
+});

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -1,6 +1,9 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getConfigurationWithDefault } from "../src/extension/configuration";
+import {
+  getConfigurationWithDefault,
+  getCompletionQueryScope,
+} from "../src/extension/configuration";
 
 describe("Configuration", () => {
   describe("getConfigurationWithDefault", () => {
@@ -63,6 +66,31 @@ describe("Configuration", () => {
         "startupOptions",
       );
       assert.deepStrictEqual(result, ["--option"]);
+    });
+  });
+
+  describe("getCompletionQueryScope", () => {
+    afterEach(async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.completion")
+        .update("queryScope", undefined, vscode.ConfigurationTarget.Workspace);
+    });
+
+    it("should return empty array by default", () => {
+      const result = getCompletionQueryScope();
+      assert.deepStrictEqual(result, []);
+    });
+
+    it("should return configured patterns", async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.completion")
+        .update(
+          "queryScope",
+          ["//src/...", "//lib/..."],
+          vscode.ConfigurationTarget.Workspace,
+        );
+      const result = getCompletionQueryScope();
+      assert.deepStrictEqual(result, ["//src/...", "//lib/..."]);
     });
   });
 });


### PR DESCRIPTION
## Description

<!-- Brief description of changes, screenshots if applicable -->
Add `bazel.completion.queryScope` setting (string array) that limits the Bazel query used by the completion provider to specific package patterns (e.g. `["//src/...", "//lib/..."]`), instead of always querying the entire workspace.

## Related Issue

<!-- Link to issue or mention if claiming an existing issue -->
<!-- e.g: Closes #123 -->
https://github.com/bazel-contrib/vscode-bazel/issues/598

## Testing

<!-- Describe how you tested your changes -->

- [x] Tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows the project's style guidelines (prettier/eslint)
- [x] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [x] Tests pass locally (`npm run test`)
