### PR TITLE
chore: Consolidate access to and naming of config vars.

### DIFF
--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -14,7 +14,7 @@
 
 import * as vscode from "vscode";
 import {
-  getDefaultBazelExecutablePath,
+  getBazelExecutablePath,
   getQueryExpression,
 } from "../extension/configuration";
 import { IBazelCommandAdapter, IBazelCommandOptions } from "./bazel_command";
@@ -193,7 +193,7 @@ export async function queryQuickPickTargets({
   }
 
   const queryResult = await new BazelQuery(
-    getDefaultBazelExecutablePath(),
+    getBazelExecutablePath(),
     workspaceInfo.workspaceFolder.uri.fsPath,
   ).queryTargets(query ?? "//...:*", { abortSignal });
 
@@ -234,7 +234,7 @@ export async function queryQuickPickPackage({
   }
 
   const packagePaths = await new BazelQuery(
-    getDefaultBazelExecutablePath(),
+    getBazelExecutablePath(),
     workspaceInfo.workspaceFolder.uri.fsPath,
   ).queryPackages(query ?? "//...", { abortSignal });
 

--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import {
   getCommandArgs,
-  getDefaultBazelExecutablePath,
+  getBazelExecutablePath,
   getStartupOptions,
 } from "../extension/configuration";
 import { IBazelCommandOptions } from "./bazel_command";
@@ -160,7 +160,7 @@ async function onTaskProcessEnd(event: vscode.TaskProcessEndEvent) {
     // Find the coverage file and load it.
     const workspaceInfo = await getWorkspaceInfoFromTask(task.scope);
     const bazelInfo = new BazelInfo(
-      getDefaultBazelExecutablePath(),
+      getBazelExecutablePath(),
       workspaceInfo.bazelWorkspacePath,
     );
     const outputPath = await bazelInfo.getOne("output_path");
@@ -277,7 +277,7 @@ export function createBazelTaskFromDefinition(
     workspaceInfo.workspaceFolder || vscode.TaskScope.Workspace,
     `${commandDescription} ${targetsDescription}`,
     "bazel",
-    new vscode.ShellExecution(getDefaultBazelExecutablePath(), args, {
+    new vscode.ShellExecution(getBazelExecutablePath(), args, {
       cwd: workspaceInfo.bazelWorkspacePath,
     }),
   );

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 import * as child_process from "child_process";
-import * as path from "path";
 import * as util from "util";
 import * as vscode from "vscode";
 
 import { IBuildifierResult, IBuildifierWarning } from "./buildifier_result";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import {
+  getBazelExecutablePath,
+  getBuildifierExecutablePath,
+  getBuildifierJsonConfigPath,
+} from "../extension/configuration";
 
 const execFile = util.promisify(child_process.execFile);
 type PromiseExecFileException = child_process.ExecFileException & {
@@ -117,36 +120,6 @@ export async function buildifierLint(
 }
 
 /**
- * Gets the path to the buildifier executable specified by the workspace
- * configuration.
- *
- * @returns The path to the buildifier executable specified in the workspace
- * configuration, or its default.
- */
-export function getDefaultBuildifierExecutablePath(): string {
-  return (
-    vscode.workspace
-      .getConfiguration("bazel")
-      .get<string>("buildifierExecutable")
-      .trim() || "buildifier"
-  );
-}
-
-/**
- * Gets the path to the buildifier json configuration file specified by the
- * workspace configuration.
- *
- * @returns The path to the buildifier json configuration file specified in the
- * workspace configuration, or its default.
- */
-export function getDefaultBuildifierJsonConfigPath(): string {
-  return vscode.workspace
-    .getConfiguration("bazel")
-    .get<string>("buildifierConfigJsonPath")
-    .trim();
-}
-
-/**
  * Executes buildifier with the given file content and arguments.
  *
  * @param fileContent The BUILD or .bzl file content to process, which is sent
@@ -154,22 +127,25 @@ export function getDefaultBuildifierJsonConfigPath(): string {
  * @param args Command line arguments to pass to buildifier.
  * @param acceptNonSevereErrors If true, syntax/lint exit codes will not be
  * treated as severe tool errors.
+ * @param executable Optional custom executable path to use instead of the default.
  */
 export async function executeBuildifier(
   fileContent: string,
   args: string[],
   acceptNonSevereErrors: boolean,
+  executable?: string,
 ): Promise<{ stdout: string; stderr: string }> {
   // Determine the executable
-  let executable = getDefaultBuildifierExecutablePath();
-  const buildifierConfigJsonPath = getDefaultBuildifierJsonConfigPath();
+  let buildifierExecutable =
+    executable || (await getBuildifierExecutablePath());
+  const buildifierConfigJsonPath = getBuildifierJsonConfigPath();
   if (buildifierConfigJsonPath.length !== 0) {
     args = ["--config", buildifierConfigJsonPath, ...args];
   }
   // Paths starting with an `@` are referring to Bazel targets
-  if (executable.startsWith("@")) {
-    const targetName = executable;
-    executable = getDefaultBazelExecutablePath();
+  if (buildifierExecutable.startsWith("@")) {
+    const targetName = buildifierExecutable;
+    buildifierExecutable = getBazelExecutablePath();
     args = ["run", targetName, "--", ...args];
   }
   const execOptions = {
@@ -180,7 +156,7 @@ export async function executeBuildifier(
   };
 
   // Start buildifier
-  const process = execFile(executable, args, execOptions);
+  const process = execFile(buildifierExecutable, args, execOptions);
 
   // Write the file being linted/formatted to stdin and close the stream so
   // that the buildifier process continues.

--- a/src/buildifier/buildifier_availability.ts
+++ b/src/buildifier/buildifier_availability.ts
@@ -17,10 +17,8 @@ import * as path from "path";
 import * as vscode from "vscode";
 import which from "which";
 
-import {
-  executeBuildifier,
-  getDefaultBuildifierExecutablePath,
-} from "./buildifier";
+import { executeBuildifier } from "./buildifier";
+import { getBuildifierExecutablePath } from "../extension/configuration";
 import { logWarn } from "../extension/logger";
 
 async function fileExists(filename: string) {
@@ -53,7 +51,7 @@ const BUILDTOOLS_RELEASES_URL =
  * @returns absolute path to the found buildifier executable, or null if not found
  */
 export async function checkBuildifierIsAvailable(): Promise<string | null> {
-  const buildifierExecutable = getDefaultBuildifierExecutablePath();
+  const buildifierExecutable = getBuildifierExecutablePath();
 
   // Check if the program exists (in case it's an actual executable and not
   // an target name starting with `@`).
@@ -90,6 +88,7 @@ export async function checkBuildifierIsAvailable(): Promise<string | null> {
     // a .buildifer.json with a different value is present
     ["--format=json", "--mode=check", "--lint=off"],
     false,
+    executablePath,
   );
   try {
     JSON.parse(stdout);

--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 
 import { BazelWorkspaceInfo, QueryLocation } from "../bazel";
 import { getTargetsForBuildFile } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import { getBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { CodeLensCommandAdapter } from "./code_lens_command_adapter";
 
@@ -103,7 +103,7 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     const queryResult = await getTargetsForBuildFile(
-      getDefaultBazelExecutablePath(),
+      getBazelExecutablePath(),
       workspaceInfo.bazelWorkspacePath,
       document.uri.fsPath,
     );

--- a/src/definition/bazel_goto_definition_provider.ts
+++ b/src/definition/bazel_goto_definition_provider.ts
@@ -22,7 +22,7 @@ import {
 } from "vscode";
 import { Utils } from "vscode-uri";
 import { BazelQuery, BazelWorkspaceInfo, QueryLocation } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import { getBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 
 // LABEL_REGEX matches label strings, e.g. @r//x/y/z:abc
@@ -45,7 +45,7 @@ export async function targetToUri(
   }
 
   const queryResult = await new BazelQuery(
-    getDefaultBazelExecutablePath(),
+    getBazelExecutablePath(),
     workingDirectory.fsPath,
   ).queryTargets(`kind(rule, "${targetName}") + kind(file, "${targetName}")`);
 

--- a/src/extension/bazel_wrapper_commands.ts
+++ b/src/extension/bazel_wrapper_commands.ts
@@ -20,7 +20,7 @@ import { logError, logInfo, showInfoMessage, showUserMessage } from "./logger";
 import { BazelWorkspaceInfo } from "../bazel/bazel_workspace_info";
 import {
   getCommandArgs,
-  getDefaultBazelExecutablePath,
+  getBazelExecutablePath,
   getStartupOptions,
 } from "./configuration";
 import {
@@ -154,7 +154,7 @@ async function bazelBuildTargetWithDebugging(
   const debugStarted = await vscode.debug.startDebugging(undefined, {
     args: fullArgs,
     bazelCommand: "build",
-    bazelExecutablePath: getDefaultBazelExecutablePath(),
+    bazelExecutablePath: getBazelExecutablePath(),
     bazelStartupOptions: startupOptions,
     cwd: commandOptions.workspaceInfo.bazelWorkspacePath,
     name: "On-demand Bazel Build Debug",

--- a/src/extension/command_variables.ts
+++ b/src/extension/command_variables.ts
@@ -14,7 +14,7 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
-import { getDefaultBazelExecutablePath } from "./configuration";
+import { getBazelExecutablePath } from "./configuration";
 import { showInfoMessage } from "./logger";
 import {
   BazelTargetQuickPick,
@@ -85,11 +85,11 @@ async function bazelGetTargetOutput(
     return;
   }
   const outputPath = await new BazelInfo(
-    getDefaultBazelExecutablePath(),
+    getBazelExecutablePath(),
     workspaceInfo.bazelWorkspacePath,
   ).getOne("output_path");
   const outputs = await new BazelCQuery(
-    getDefaultBazelExecutablePath(),
+    getBazelExecutablePath(),
     workspaceInfo.bazelWorkspacePath,
   ).queryOutputs(target, options);
   switch (outputs.length) {
@@ -119,7 +119,7 @@ async function bazelInfo(key: string): Promise<string> {
     return;
   }
   return new BazelInfo(
-    getDefaultBazelExecutablePath(),
+    getBazelExecutablePath(),
     workspaceInfo.bazelWorkspacePath,
   ).getOne(key);
 }

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -49,7 +49,7 @@ export function getConfigurationWithDefault<T>(
  * @returns The path to the Bazel executable specified in the workspace
  * configuration, or its default.
  */
-export function getDefaultBazelExecutablePath(): string {
+export function getBazelExecutablePath(): string {
   return getConfigurationWithDefault<string>("bazel", "executable").trim();
 }
 
@@ -71,5 +71,53 @@ export function getQueryExpression(): string {
   return getConfigurationWithDefault<string>(
     "bazel.commandLine",
     "queryExpression",
+  );
+}
+
+/**
+ * Gets the path to the buildifier executable specified by the workspace
+ * configuration.
+ *
+ * @returns The path to the buildifier executable specified in the workspace
+ * configuration, or its default.
+ */
+export function getBuildifierExecutablePath(): string {
+  return getConfigurationWithDefault<string>(
+    "bazel",
+    "buildifierExecutable",
+  ).trim();
+}
+
+/**
+ * Gets the path to the buildifier json configuration file specified by the
+ * workspace configuration.
+ *
+ * @returns The path to the buildifier json configuration file specified in the
+ * workspace configuration, or its default.
+ */
+export function getBuildifierJsonConfigPath(): string {
+  return getConfigurationWithDefault<string>(
+    "bazel",
+    "buildifierConfigJsonPath",
+  ).trim();
+}
+
+/**
+ * Gets the path to the buildifier json configuration file specified by the
+ * workspace configuration.
+ *
+ * @returns The path to the buildifier json configuration file specified in the
+ * workspace configuration, or its default.
+ */
+export function getLspServerExecutablePath(): string {
+  return getConfigurationWithDefault<string>("bazel.lsp", "command").trim();
+}
+export function getLspServerArgs(): string[] {
+  return getConfigurationWithDefault<string[]>("bazel.lsp", "args");
+}
+export function getLspServerEnv(): Record<string, string> {
+  return getConfigurationWithDefault<Record<string, string>>(
+    "bazel.lsp",
+    "env",
   );
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -33,6 +33,7 @@ import { activateCommandVariables } from "./command_variables";
 import { activateTesting } from "../test-explorer";
 import { activateWrapperCommands } from "./bazel_wrapper_commands";
 import { registerLogger, logInfo, logError, showOutputChannel } from "./logger";
+import { startLspClientFromCurrentConfig } from "../lsp/language-server-client";
 
 // Global reference to the workspace tree provider for testing
 declare global {
@@ -84,51 +85,16 @@ export async function activate(context: vscode.ExtensionContext) {
   let completionItemProvider: BazelCompletionItemProvider | null = null;
   let lspClient: lc.LanguageClient | undefined;
 
-  async function startLspFromCurrentConfig() {
-    const currentConfig = vscode.workspace.getConfiguration("bazel");
-    const lspCommand = !!currentConfig.get<string>("lsp.command");
-
-    if (!lspCommand) {
-      logError(
-        "Bazel LSP command (bazel.lsp.command) is not configured.",
-        true,
-        "Configuration: %s",
-        JSON.stringify(currentConfig),
-      );
-      return;
-    }
-
-    if (lspClient) {
-      try {
-        await lspClient.stop();
-      } catch {
-        // Ignore errors while stopping a previous client instance.
-      }
-    }
-
-    const newClient = createLsp(currentConfig);
-    lspClient = newClient;
-    context.subscriptions.push(newClient);
-
-    try {
-      await lspClient.start();
-    } catch (error: any) {
-      logError("Failed to start Bazel language server", true, error);
-    }
-  }
-
-  // Initialize other parts of the extension
+  // Set up LSP if enabled
   const config = vscode.workspace.getConfiguration("bazel");
   const lspEnabled = !!config.get<string>("lsp.command");
-
-  // Set up LSP if enabled
   if (lspEnabled) {
     context.subscriptions.push(
       vscode.commands.registerCommand("bazel.lsp.restart", async () => {
-        await startLspFromCurrentConfig();
+        await startLspClientFromCurrentConfig(lspClient, context);
       }),
     );
-    await startLspFromCurrentConfig();
+    await startLspClientFromCurrentConfig(lspClient, context);
   } else {
     completionItemProvider = new BazelCompletionItemProvider();
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -242,34 +208,4 @@ export async function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
   // Nothing to do here.
   logInfo("Extension deactivated.");
-}
-
-function createLsp(config: vscode.WorkspaceConfiguration) {
-  const command = config.get<string>("lsp.command");
-  const args = config.get<string[]>("lsp.args");
-  const env = config.get<Record<string, string>>("lsp.env");
-
-  const run: lc.Executable = {
-    args,
-    command,
-    options: {
-      env: { ...process.env, ...env },
-    },
-  };
-
-  const serverOptions: lc.ServerOptions = {
-    run,
-    debug: run,
-  };
-
-  const clientOptions: lc.LanguageClientOptions = {
-    documentSelector: [{ scheme: "file", language: "starlark" }],
-  };
-
-  return new lc.LanguageClient(
-    "bazel",
-    "Bazel LSP Client",
-    serverOptions,
-    clientOptions,
-  );
 }

--- a/src/lsp/language-server-client.ts
+++ b/src/lsp/language-server-client.ts
@@ -1,0 +1,78 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as lc from "vscode-languageclient/node";
+import * as vscode from "vscode";
+import { logError } from "../extension/logger";
+import {
+  getLspServerArgs,
+  getLspServerEnv,
+  getLspServerExecutablePath,
+} from "../extension/configuration";
+
+export async function startLspClientFromCurrentConfig(
+  lspClient: lc.LanguageClient | undefined,
+  context: vscode.ExtensionContext,
+) {
+  if (lspClient) {
+    try {
+      await lspClient.stop();
+    } catch {
+      // Ignore errors while stopping a previous client instance.
+    }
+  }
+
+  try {
+    const newClient = await _createLspClient();
+    lspClient = newClient;
+    context.subscriptions.push(newClient);
+    await lspClient.start();
+  } catch (error: any) {
+    logError("Failed to start Bazel language server", true, error);
+  }
+}
+
+async function _createLspClient(): Promise<lc.LanguageClient> {
+  const lspServerExecutable = getLspServerExecutablePath();
+  if (!lspServerExecutable) {
+    throw new Error("LSP server executable not configured");
+  }
+
+  const args = getLspServerArgs();
+  const env = getLspServerEnv();
+
+  const lspServer: lc.Executable = {
+    args,
+    command: lspServerExecutable,
+    options: {
+      env: { ...process.env, ...env },
+    },
+  };
+
+  const serverOptions: lc.ServerOptions = {
+    run: lspServer,
+    debug: lspServer,
+  };
+
+  const clientOptions: lc.LanguageClientOptions = {
+    documentSelector: [{ scheme: "file", language: "starlark" }],
+  };
+
+  return new lc.LanguageClient(
+    "bazel",
+    "Bazel LSP Client",
+    serverOptions,
+    clientOptions,
+  );
+}

--- a/src/symbols/bazel_target_symbol_provider.ts
+++ b/src/symbols/bazel_target_symbol_provider.ts
@@ -17,7 +17,7 @@ import { DocumentSymbolProvider } from "vscode";
 
 import { BazelWorkspaceInfo, QueryLocation } from "../bazel";
 import { getTargetsForBuildFile } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import { getBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 
 /** Provids Symbols for targets in Bazel BUILD files. */
@@ -32,7 +32,7 @@ export class BazelTargetSymbolProvider implements DocumentSymbolProvider {
     }
 
     const queryResult = await getTargetsForBuildFile(
-      getDefaultBazelExecutablePath(),
+      getBazelExecutablePath(),
       workspaceInfo.bazelWorkspacePath,
       document.uri.fsPath,
     );

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -19,7 +19,7 @@ import {
   IBazelCommandAdapter,
   IBazelCommandOptions,
 } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import { getBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
 import { IBazelTreeItem } from "./bazel_tree_item";
@@ -56,7 +56,7 @@ export class BazelPackageTreeItem
 
   public async getChildren(): Promise<IBazelTreeItem[]> {
     const queryResult = await new BazelQuery(
-      getDefaultBazelExecutablePath(),
+      getBazelExecutablePath(),
       this.workspaceInfo.bazelWorkspacePath,
     ).queryTargets(`//${this.packagePath}:all`, {
       ignoresErrors: true,

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import { BazelWorkspaceInfo, BazelQuery } from "../bazel";
 import {
-  getDefaultBazelExecutablePath,
+  getBazelExecutablePath,
   getQueryExpression,
 } from "../extension/configuration";
 import { blaze_query } from "../protos";
@@ -201,7 +201,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     }
     const workspacePath = this.workspaceInfo.workspaceFolder.uri.fsPath;
     const packagePaths = await new BazelQuery(
-      getDefaultBazelExecutablePath(),
+      getBazelExecutablePath(),
       workspacePath,
     ).queryPackages(getQueryExpression());
     const topLevelItems: BazelPackageTreeItem[] = [];
@@ -216,7 +216,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     // Now collect any targets in the directory also (this can fail since
     // there might not be a BUILD files at this level (but down levels)).
     const queryResult = await new BazelQuery(
-      getDefaultBazelExecutablePath(),
+      getBazelExecutablePath(),
       workspacePath,
     ).queryTargets(`:all`, {
       ignoresErrors: true,


### PR DESCRIPTION
## Description

This is a breakout of #603 to ease review once that PR becomes ready.

Changes in this PR:
- Rename of config getters, e.g. `getDefaultBazelExecutablePath` to `getBazelExecutablePath`
- Addition of multiple getters to `configuration.ts`
- Extract (and refactor) setup of lsp out of `extension.ts` into it's own directory (preparation for turning it into a `ExtensionFeature`)
- Fix in `buildifier_availability`: Pass executable that is to be validated (first step for reducing implicit duplication in figuring out which executable to use).

## Related Issue

Related to #371 

## Testing

<!-- Describe how you tested your changes -->

- [ ] Tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Code follows the project's style guidelines (prettier/eslint)
- [ ] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [ ] Tests pass locally (`npm run test`)
