### PR TITLE
fix: window path issues for go to commands

### DIFF
--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -206,10 +206,9 @@ export function getBuildFileLineWithSourceFilePath(
   sourceFilePath: string,
 ): number | undefined {
   // Find the line number where the current editors file is mentioned
-  const relativeSourcePath = path.relative(
-    path.dirname(buildFilePath),
-    sourceFilePath,
-  );
+  const relativeSourcePath = path
+    .relative(path.dirname(buildFilePath), sourceFilePath)
+    .replace(/\\/g, "/");
   const buildFileContent = fs
     .readFileSync(buildFilePath, "utf8")
     .trim()

--- a/src/extension/bazel_wrapper_commands.ts
+++ b/src/extension/bazel_wrapper_commands.ts
@@ -38,6 +38,7 @@ import {
 import { createBazelTask } from "../bazel/tasks";
 import { blaze_query } from "../protos";
 import { CodeLensCommandAdapter } from "../codelens/code_lens_command_adapter";
+import { QueryLocation } from "../bazel/query_location";
 
 /**
  * Unified target selection logic that handles all 3 use cases:
@@ -419,15 +420,12 @@ async function bazelGoToLabel(target_info?: blaze_query.ITarget | undefined) {
   }
 
   const location = target_info.rule.location;
-  const [filePath, line, column] = location.split(":");
-  const position = new vscode.Position(
-    parseInt(line, 10) - 1, // Convert to 0-based line number
-    parseInt(column || "0", 10) - 1, // Convert to 0-based column number, default to 0
-  );
+  const queryLocation = new QueryLocation(location);
+  const position = queryLocation.range.start;
 
   // Open the document and reveal the position
   const document = await vscode.workspace.openTextDocument(
-    vscode.Uri.file(filePath),
+    vscode.Uri.file(queryLocation.path),
   );
   await vscode.window.showTextDocument(document, {
     selection: new vscode.Range(position, position),


### PR DESCRIPTION
## Description

There were two issues.

First, in GoToBuild we try to find a relative path of a BUILD file by a relative path in a BUILD file. The relative path in the BUILD file is always using "/" as separators, but the path.relative js function returns a path with "\\" separators under windows. Therefore, we need to replace "\\" with "/" to match the relative path from the BUILD file.

Second, in GoToLabel we split the current file location by ":". Under windows this does not work, since the path contains an additional colon at the start, e.g. C:\\work\\BUILD:20:3. I use QueryLocation since this already handles the windows path issues. If QueryLocation should not be used here, let me know and I try to come up with a different solution.

## Related Issue

Closes #616 

## Testing

Run the previous failing unittests and see them passing.

## Checklist

- [x] Code follows the project's style guidelines (prettier/eslint)
- [x] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [x] Tests pass locally (`npm run test`)
