### PR TITLE
fix(workspace-tree): make bazel.commandLine.queryExpression behave more similarly to bazel query

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
                 "bazel.commandLine.queryExpression": {
                     "type": "string",
                     "default": "...:*",
-                    "description": "A [query language expression](https://bazel.build/query/language) which determines the packages displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*`"
+                    "description": "A [query language expression](https://bazel.build/query/language) which determines the packages and targets displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*` or `kind('.*_test rule', //...)`"
                 },
                 "bazel.lsp.command": {
                     "type": "string",

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -19,7 +19,10 @@ import {
   IBazelCommandAdapter,
   IBazelCommandOptions,
 } from "../bazel";
-import { getBazelExecutablePath } from "../extension/configuration";
+import {
+  getBazelExecutablePath,
+  getQueryExpression,
+} from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
 import { IBazelTreeItem } from "./bazel_tree_item";
@@ -55,10 +58,12 @@ export class BazelPackageTreeItem
   }
 
   public async getChildren(): Promise<IBazelTreeItem[]> {
+    const queryExpression = getQueryExpression();
+    const targetQuery = `(${queryExpression}) intersect (//${this.packagePath}:all)`;
     const queryResult = await new BazelQuery(
       getBazelExecutablePath(),
       this.workspaceInfo.bazelWorkspacePath,
-    ).queryTargets(`//${this.packagePath}:all`, {
+    ).queryTargets(targetQuery, {
       ignoresErrors: true,
       sortByRuleName: true,
     });

--- a/test/workspace_tree.test.ts
+++ b/test/workspace_tree.test.ts
@@ -204,10 +204,7 @@ describe("Bazel Workspace Tree", function (this: Mocha.Suite) {
           vscode.ConfigurationTarget.Workspace,
         );
 
-      await verifyTreeStructure(
-        {},
-        await workspaceTreeProvider.getChildren(),
-      );
+      await verifyTreeStructure({}, await workspaceTreeProvider.getChildren());
     });
   });
 

--- a/test/workspace_tree.test.ts
+++ b/test/workspace_tree.test.ts
@@ -122,6 +122,95 @@ describe("Bazel Workspace Tree", function (this: Mocha.Suite) {
     );
   });
 
+  describe("queryExpression filtering", () => {
+    afterEach(async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.commandLine")
+        .update(
+          "queryExpression",
+          undefined,
+          vscode.ConfigurationTarget.Workspace,
+        );
+    });
+
+    it("should filter targets by rule kind", async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.commandLine")
+        .update(
+          "queryExpression",
+          "kind('py_.*', //...)",
+          vscode.ConfigurationTarget.Workspace,
+        );
+
+      await verifyTreeStructure(
+        {
+          "//pkg1": {
+            ":main  (py_binary)": {},
+            ":pkg1  (py_library)": {},
+          },
+        },
+        await workspaceTreeProvider.getChildren(),
+      );
+    });
+
+    it("should filter to filegroup targets only", async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.commandLine")
+        .update(
+          "queryExpression",
+          "kind('filegroup', //...)",
+          vscode.ConfigurationTarget.Workspace,
+        );
+
+      await verifyTreeStructure(
+        {
+          "//pkg1": {
+            ":foo  (filegroup)": {},
+            ":src_files  (filegroup)": {},
+          },
+          "//pkg2/sub-pkg": {
+            ":foobar  (filegroup)": {},
+          },
+        },
+        await workspaceTreeProvider.getChildren(),
+      );
+    });
+
+    it("should filter to a single target", async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.commandLine")
+        .update(
+          "queryExpression",
+          "//pkg1:main",
+          vscode.ConfigurationTarget.Workspace,
+        );
+
+      await verifyTreeStructure(
+        {
+          "//pkg1": {
+            ":main  (py_binary)": {},
+          },
+        },
+        await workspaceTreeProvider.getChildren(),
+      );
+    });
+
+    it("should show empty tree when expression matches nothing", async () => {
+      await vscode.workspace
+        .getConfiguration("bazel.commandLine")
+        .update(
+          "queryExpression",
+          "kind('java_library', //...)",
+          vscode.ConfigurationTarget.Workspace,
+        );
+
+      await verifyTreeStructure(
+        {},
+        await workspaceTreeProvider.getChildren(),
+      );
+    });
+  });
+
   it("does not select tree item when bazel view is hidden", async () => {
     // GIVEN another view is active (Search) instead of the Explorer
     await vscode.commands.executeCommand("workbench.view.search");


### PR DESCRIPTION
## Related Issue
Fixes #618

## Summary

The Bazel Targets tree view only partially applied `bazel.commandLine.queryExpression`. `queryPackages()` honored the setting, so packages with no matching targets were hidden, but the target-listing queries were hardcoded to `:all` and `//pkg:all`, letting non-matching targets leak through at the workspace root and inside every surviving package.

This change intersects both target queries with the configured expression so the tree matches what `bazel query <expression>` returns.

## Example
A minimal standalone repro workspace is at https://github.com/janantharaj/vscode-bazel-queryexpr-repro.
With `"bazel.commandLine.queryExpression": "kind('genrule', //...)"` set:

Before:
<img width="361" height="268" alt="Screenshot 2026-04-20 at 4 42 21 PM" src="https://github.com/user-attachments/assets/2f8762ed-3d1e-4700-b135-9f6fa6bd4061" />

```
:root_alias               (alias)       # not a genrule, still shown
:root_files               (filegroup)   # not a genrule, still shown
:root_gen                 (genrule)
pkg_app
  :app                    (genrule)
  :app_alias              (alias)       # not a genrule, still shown
pkg_lib
  :concat                 (genrule)
  :sources                (filegroup)   # not a genrule, still shown
```

After:
<img width="360" height="165" alt="Screenshot 2026-04-20 at 4 44 26 PM" src="https://github.com/user-attachments/assets/91870739-7bed-48de-a8a8-a77220d2523f" />

```
:root_gen                 (genrule)
pkg_app
  :app                    (genrule)
pkg_lib
  :concat                 (genrule)
```


## Changes

- `src/workspace-tree/bazel_package_tree_item.ts`: query `(<expr>) intersect //<pkg>:all` instead of `//<pkg>:all`.
- `src/workspace-tree/bazel_workspace_folder_tree_item.ts`: query `(<expr>) intersect :all` instead of `:all` for root-level targets.
- `package.json`: update the `bazel.commandLine.queryExpression` description to mention targets (not just packages) and show a `kind()` example.
- `test/workspace_tree.test.ts`: new `queryExpression filtering` suite covering rule-kind filters, single-target filters, and empty-match filters.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint-check`
- [x] `npm run format-check`
- [x] `npm test` (117 passing, including four new `queryExpression filtering` tests)
- [x] Manual verification against the [repro workspace](https://github.com/janantharaj/vscode-bazel-queryexpr-repro) with `kind('genrule', //...)`, `kind('filegroup', //...)`, and `//pkg_app:app`