### PR TITLE
fix: update @vscode/vsce to 2.25.0 to resolve UUID vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "@typescript-eslint/parser": "^8.44.1",
                 "@vscode/test-cli": "^0.0.12",
                 "@vscode/test-electron": "^2.3.9",
-                "@vscode/vsce": "^3.0.0",
+                "@vscode/vsce": "2.25.0",
                 "esbuild": "^0.28.0",
                 "eslint": "^10.0.0",
                 "eslint-config-prettier": "^10.0.0",
@@ -52,252 +52,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@azu/format-text": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
-            "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
-            "dev": true
-        },
-        "node_modules/@azu/style-format": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
-            "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
-            "dev": true,
-            "dependencies": {
-                "@azu/format-text": "^1.0.1"
-            }
-        },
-        "node_modules/@azure/abort-controller": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-            "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/core-auth": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
-            "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
-            "dev": true,
-            "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-util": "^1.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-client": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
-            "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
-            "dev": true,
-            "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-auth": "^1.4.0",
-                "@azure/core-rest-pipeline": "^1.9.1",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.6.1",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.15.2.tgz",
-            "integrity": "sha512-BmWfpjc/QXc2ipHOh6LbUzp3ONCaa6xzIssTU0DwH9bbYNXJlGUL6tujx5TrbVd/QQknmS+vlQJGrCq2oL1gZA==",
-            "dev": true,
-            "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-auth": "^1.4.0",
-                "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.3.0",
-                "@azure/logger": "^1.0.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-tracing": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
-            "integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-util": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
-            "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
-            "dev": true,
-            "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/identity": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.2.1.tgz",
-            "integrity": "sha512-U8hsyC9YPcEIzoaObJlRDvp7KiF0MGS7xcWbyJSVvXRkC/HXo1f0oYeBYmEvVgRfacw7GHf6D6yAoh9JHz6A5Q==",
-            "dev": true,
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.5.0",
-                "@azure/core-client": "^1.4.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.3.0",
-                "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^3.11.1",
-                "@azure/msal-node": "^2.9.2",
-                "events": "^3.0.0",
-                "jws": "^4.0.0",
-                "open": "^8.0.0",
-                "stoppable": "^1.1.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/logger": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.2.tgz",
-            "integrity": "sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/msal-browser": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.13.0.tgz",
-            "integrity": "sha512-fD906nmJei3yE7la6DZTdUtXKvpwzJURkfsiz9747Icv4pit77cegSm6prJTKLQ1fw4iiZzrrWwxnhMLrTf5gQ==",
-            "dev": true,
-            "dependencies": {
-                "@azure/msal-common": "14.9.0"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@azure/msal-common": {
-            "version": "14.9.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
-            "integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@azure/msal-node": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.9.2.tgz",
-            "integrity": "sha512-8tvi6Cos3m+0KmRbPjgkySXi+UQU/QiuVRFnrxIwt5xZlEEFa69O04RTaNESGgImyBBlYbo2mfE8/U8Bbdk1WQ==",
-            "dev": true,
-            "dependencies": {
-                "@azure/msal-common": "14.12.0",
-                "jsonwebtoken": "^9.0.0",
-                "uuid": "^8.3.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-            "version": "14.12.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.12.0.tgz",
-            "integrity": "sha512-IDDXmzfdwmDkv4SSmMEyAniJf6fDu3FJ7ncOjlxkDuT85uSnLEhZi3fGZpoR7T4XZpOMx9teM9GXBgrfJgyeBw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -1179,41 +933,6 @@
                 "node": ">=v12.0.0"
             }
         },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1278,233 +997,10 @@
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
-        "node_modules/@secretlint/config-creator": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
-            "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/types": "^10.2.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/config-loader": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
-            "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/profiler": "^10.2.2",
-                "@secretlint/resolver": "^10.2.2",
-                "@secretlint/types": "^10.2.2",
-                "ajv": "^8.17.1",
-                "debug": "^4.4.1",
-                "rc-config-loader": "^4.1.3"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/config-loader/node_modules/ajv": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@secretlint/config-loader/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
-        },
-        "node_modules/@secretlint/core": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
-            "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/profiler": "^10.2.2",
-                "@secretlint/types": "^10.2.2",
-                "debug": "^4.4.1",
-                "structured-source": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/formatter": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
-            "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/resolver": "^10.2.2",
-                "@secretlint/types": "^10.2.2",
-                "@textlint/linter-formatter": "^15.2.0",
-                "@textlint/module-interop": "^15.2.0",
-                "@textlint/types": "^15.2.0",
-                "chalk": "^5.4.1",
-                "debug": "^4.4.1",
-                "pluralize": "^8.0.0",
-                "strip-ansi": "^7.1.0",
-                "table": "^6.9.0",
-                "terminal-link": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/formatter/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/@secretlint/formatter/node_modules/chalk": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@secretlint/formatter/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@secretlint/node": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
-            "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/config-loader": "^10.2.2",
-                "@secretlint/core": "^10.2.2",
-                "@secretlint/formatter": "^10.2.2",
-                "@secretlint/profiler": "^10.2.2",
-                "@secretlint/source-creator": "^10.2.2",
-                "@secretlint/types": "^10.2.2",
-                "debug": "^4.4.1",
-                "p-map": "^7.0.3"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/profiler": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
-            "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
-            "dev": true
-        },
-        "node_modules/@secretlint/resolver": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
-            "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
-            "dev": true
-        },
-        "node_modules/@secretlint/secretlint-formatter-sarif": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
-            "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
-            "dev": true,
-            "dependencies": {
-                "node-sarif-builder": "^3.2.0"
-            }
-        },
-        "node_modules/@secretlint/secretlint-rule-no-dotenv": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
-            "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/types": "^10.2.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/secretlint-rule-preset-recommend": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
-            "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
-            "dev": true,
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/source-creator": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
-            "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/types": "^10.2.2",
-                "istextorbinary": "^9.5.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@secretlint/types": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
-            "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
-            "dev": true,
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@sindresorhus/base62": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
             "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@sindresorhus/merge-streams": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
             "dev": true,
             "engines": {
                 "node": ">=18"
@@ -1552,61 +1048,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/@textlint/ast-node-types": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.0.tgz",
-            "integrity": "sha512-K0LEuuTo4rza8yDrlYkRdXLao8Iz/QBMsQdIxRrOOrLYb4HAtZaypZ78c+J6rDA1UlGxadZVLmkkiv4KV5fMKQ==",
-            "dev": true
-        },
-        "node_modules/@textlint/linter-formatter": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.0.tgz",
-            "integrity": "sha512-DPTm2+VXKID41qKQWagg/4JynM6hEEpvbq0PlGsEoC4Xm7IqXIxFym3mSf5+ued0cuiIV1hR9kgXjqGdP035tw==",
-            "dev": true,
-            "dependencies": {
-                "@azu/format-text": "^1.0.2",
-                "@azu/style-format": "^1.0.1",
-                "@textlint/module-interop": "15.5.0",
-                "@textlint/resolver": "15.5.0",
-                "@textlint/types": "15.5.0",
-                "chalk": "^4.1.2",
-                "debug": "^4.4.3",
-                "js-yaml": "^4.1.1",
-                "lodash": "^4.17.21",
-                "pluralize": "^2.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "table": "^6.9.0",
-                "text-table": "^0.2.0"
-            }
-        },
-        "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
-            "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
-            "dev": true
-        },
-        "node_modules/@textlint/module-interop": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.0.tgz",
-            "integrity": "sha512-rqfouEhBEgZlR9umswWXXRBcmmSM28Trpr9b0duzgehKYVc7wSQCuQMagr6YBJa2NRMfRNinupusbJXMg0ij2A==",
-            "dev": true
-        },
-        "node_modules/@textlint/resolver": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.0.tgz",
-            "integrity": "sha512-kK5nFbg5N3kVoZExQI/dnYjCInmTltvXDnuCRrBxHI01i6kO/o8R7Lc2aFkAZ6/NUZuRPalkyDdwZJke4/R2wg==",
-            "dev": true
-        },
-        "node_modules/@textlint/types": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.0.tgz",
-            "integrity": "sha512-EjAPbuA+3NyQ9WyFP7iUlddi35F3mGrf4tb4cZM0nWywbtEJ3+XAYqL+5RsF0qFeSguxGir09NdZOWrG9wVOUQ==",
-            "dev": true,
-            "dependencies": {
-                "@textlint/ast-node-types": "15.5.0"
             }
         },
         "node_modules/@types/esrecurse": {
@@ -1670,18 +1111,6 @@
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
-        },
-        "node_modules/@types/normalize-package-data": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-            "dev": true
-        },
-        "node_modules/@types/sarif": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
-            "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
-            "dev": true
         },
         "node_modules/@types/sinon": {
             "version": "21.0.1",
@@ -2096,35 +1525,29 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
-            "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+            "version": "2.25.0",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.25.0.tgz",
+            "integrity": "sha512-VXMCGUaP6wKBadA7vFQdsksxkBAMoh4ecZgXBwauZMASAgnwYesHyLnqIyWYeRwjy2uEpitHvz/1w5ENnR30pg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@azure/identity": "^4.1.0",
-                "@secretlint/node": "^10.1.2",
-                "@secretlint/secretlint-formatter-sarif": "^10.1.2",
-                "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
-                "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
-                "@vscode/vsce-sign": "^2.0.0",
                 "azure-devops-node-api": "^12.5.0",
-                "chalk": "^4.1.2",
+                "chalk": "^2.4.2",
                 "cheerio": "^1.0.0-rc.9",
                 "cockatiel": "^3.1.2",
-                "commander": "^12.1.0",
+                "commander": "^6.2.1",
                 "form-data": "^4.0.0",
-                "glob": "^11.0.0",
+                "glob": "^7.0.6",
                 "hosted-git-info": "^4.0.2",
                 "jsonc-parser": "^3.2.0",
                 "leven": "^3.1.0",
-                "markdown-it": "^14.1.0",
+                "markdown-it": "^12.3.2",
                 "mime": "^1.3.4",
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
-                "secretlint": "^10.1.2",
                 "semver": "^7.5.2",
-                "tmp": "^0.2.3",
+                "tmp": "^0.2.1",
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
                 "xml2js": "^0.5.0",
@@ -2135,253 +1558,117 @@
                 "vsce": "vsce"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 16"
             },
             "optionalDependencies": {
                 "keytar": "^7.7.0"
             }
         },
-        "node_modules/@vscode/vsce-sign": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
-            "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+        "node_modules/@vscode/vsce/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
-            "hasInstallScript": true,
-            "optionalDependencies": {
-                "@vscode/vsce-sign-alpine-arm64": "2.0.6",
-                "@vscode/vsce-sign-alpine-x64": "2.0.6",
-                "@vscode/vsce-sign-darwin-arm64": "2.0.6",
-                "@vscode/vsce-sign-darwin-x64": "2.0.6",
-                "@vscode/vsce-sign-linux-arm": "2.0.6",
-                "@vscode/vsce-sign-linux-arm64": "2.0.6",
-                "@vscode/vsce-sign-linux-x64": "2.0.6",
-                "@vscode/vsce-sign-win32-arm64": "2.0.6",
-                "@vscode/vsce-sign-win32-x64": "2.0.6"
-            }
-        },
-        "node_modules/@vscode/vsce-sign-alpine-arm64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
-            "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "alpine"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-alpine-x64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
-            "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "alpine"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-darwin-arm64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
-            "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-darwin-x64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
-            "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-linux-arm": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
-            "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-linux-arm64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
-            "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-linux-x64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
-            "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-win32-arm64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
-            "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-win32-x64": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
-            "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@vscode/vsce/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "balanced-match": "^4.0.2"
+                "color-convert": "^1.9.0"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": ">=4"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+        "node_modules/@vscode/vsce/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vscode/vsce/node_modules/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/linkify-it": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^1.0.1"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/markdown-it": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
             },
             "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "markdown-it": "bin/markdown-it.js"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+        "node_modules/@vscode/vsce/node_modules/mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
             "dev": true,
-            "dependencies": {
-                "brace-expansion": "^5.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
+            "license": "MIT"
         },
-        "node_modules/@vscode/vsce/node_modules/jackspeak": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+        "node_modules/@vscode/vsce/node_modules/uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
             "dev": true,
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/lru-cache": {
-            "version": "11.2.4",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
-            "dev": true,
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
+            "license": "MIT"
         },
         "node_modules/acorn": {
             "version": "8.16.0",
@@ -2425,21 +1712,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ansi-escapes": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-            "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
-            "dev": true,
-            "dependencies": {
-                "environment": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-regex": {
@@ -2491,15 +1763,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "node_modules/astral-regex": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -2555,21 +1818,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/binaryextensions": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
-            "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
-            "dev": true,
-            "dependencies": {
-                "editions": "^6.21.0"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
-            }
-        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -2613,12 +1861,6 @@
             "version": "2.19.5",
             "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
             "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-            "dev": true
-        },
-        "node_modules/boundary": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
-            "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
             "dev": true
         },
         "node_modules/brace-expansion": {
@@ -2682,12 +1924,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/buffer-equal-constant-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-            "dev": true
         },
         "node_modules/c8": {
             "version": "10.1.3",
@@ -2962,12 +2198,13 @@
             }
         },
         "node_modules/commander": {
-            "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">= 6"
             }
         },
         "node_modules/comment-parser": {
@@ -3122,15 +2359,6 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
         },
-        "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3234,31 +2462,6 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
         },
-        "node_modules/ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/editions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
-            "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
-            "dev": true,
-            "dependencies": {
-                "version-range": "^4.15.0"
-            },
-            "engines": {
-                "ecmascript": ">= es5",
-                "node": ">=4"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
-            }
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3297,18 +2500,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/environment": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/es-define-property": {
@@ -3765,15 +2956,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/events": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.x"
-            }
-        },
         "node_modules/expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -3790,36 +2972,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-glob/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3830,31 +2982,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-        },
-        "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ]
-        },
-        "node_modules/fastq": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-            "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
-            "dev": true,
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
         },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
@@ -3971,20 +3098,6 @@
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "dev": true,
             "optional": true
-        },
-        "node_modules/fs-extra": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-            "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -4123,35 +3236,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-            "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-            "dev": true,
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^2.1.0",
-                "fast-glob": "^3.3.3",
-                "ignore": "^7.0.3",
-                "path-type": "^6.0.0",
-                "slash": "^5.1.0",
-                "unicorn-magic": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/gopd": {
@@ -4352,18 +3436,6 @@
                 "node": ">=0.8.19"
             }
         },
-        "node_modules/index-to-position": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
-            "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4395,21 +3467,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-extglob": {
@@ -4493,18 +3550,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4571,23 +3616,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/istextorbinary": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
-            "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
-            "dev": true,
-            "dependencies": {
-                "binaryextensions": "^6.11.0",
-                "editions": "^6.21.0",
-                "textextensions": "^6.11.0"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
-            }
-        },
         "node_modules/jackspeak": {
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -4602,12 +3630,6 @@
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
             }
-        },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
@@ -4696,78 +3718,11 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/jsonc-parser": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
             "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
             "dev": true
-        },
-        "node_modules/jsonfile": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-            "dev": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonwebtoken": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-            "dev": true,
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.1.1",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=12",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jwa": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-            "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-            "dev": true,
-            "dependencies": {
-                "buffer-equal-constant-time": "^1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jws": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-            "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-            "dev": true,
-            "dependencies": {
-                "jwa": "^1.4.2",
-                "safe-buffer": "^5.0.1"
-            }
         },
         "node_modules/jszip": {
             "version": "3.10.1",
@@ -4779,27 +3734,6 @@
                 "pako": "~1.0.2",
                 "readable-stream": "~2.3.6",
                 "setimmediate": "^1.0.5"
-            }
-        },
-        "node_modules/jwa": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-            "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-            "dev": true,
-            "dependencies": {
-                "buffer-equal-constant-time": "^1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jws": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-            "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-            "dev": true,
-            "dependencies": {
-                "jwa": "^2.0.1",
-                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/keytar": {
@@ -4891,54 +3825,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
-        },
-        "node_modules/lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-            "dev": true
-        },
-        "node_modules/lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true
-        },
-        "node_modules/lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-            "dev": true
-        },
-        "node_modules/lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-            "dev": true
-        },
-        "node_modules/lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
-        },
-        "node_modules/lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "dev": true
-        },
-        "node_modules/lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-            "dev": true
-        },
-        "node_modules/lodash.truncate": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -5042,30 +3928,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
-        },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
         },
         "node_modules/mime": {
             "version": "1.6.0",
@@ -5339,51 +4201,6 @@
             "dev": true,
             "optional": true
         },
-        "node_modules/node-sarif-builder": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
-            "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
-            "dev": true,
-            "dependencies": {
-                "@types/sarif": "^2.1.7",
-                "fs-extra": "^11.1.1"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/normalize-package-data": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-            "dev": true,
-            "dependencies": {
-                "hosted-git-info": "^7.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4"
-            },
-            "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
-        "node_modules/normalize-package-data/node_modules/hosted-git-info": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^10.0.1"
-            },
-            "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
-        "node_modules/normalize-package-data/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true
-        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5441,23 +4258,6 @@
             },
             "engines": {
                 "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-            "dev": true,
-            "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5635,18 +4435,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -5666,35 +4454,6 @@
             "dev": true,
             "dependencies": {
                 "parse-statements": "1.0.11"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "index-to-position": "^1.1.0",
-                "type-fest": "^4.39.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/parse-json/node_modules/type-fest": {
-            "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parse-semver": {
@@ -5798,18 +4557,6 @@
                 "node": "14 || >=16.14"
             }
         },
-        "node_modules/path-type": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -5832,15 +4579,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/pluralize": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/prebuild-install": {
@@ -6054,26 +4792,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -6088,18 +4806,6 @@
             },
             "bin": {
                 "rc": "cli.js"
-            }
-        },
-        "node_modules/rc-config-loader": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
-            "integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4",
-                "js-yaml": "^4.1.0",
-                "json5": "^2.2.2",
-                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/rc/node_modules/strip-json-comments": {
@@ -6122,49 +4828,6 @@
             },
             "engines": {
                 "node": ">=0.8"
-            }
-        },
-        "node_modules/read-pkg": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-            "dev": true,
-            "dependencies": {
-                "@types/normalize-package-data": "^2.4.3",
-                "normalize-package-data": "^6.0.0",
-                "parse-json": "^8.0.0",
-                "type-fest": "^4.6.0",
-                "unicorn-magic": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg/node_modules/unicorn-magic": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/readable-stream": {
@@ -6198,15 +4861,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -6249,39 +4903,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6293,27 +4914,6 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
             "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
             "dev": true
-        },
-        "node_modules/secretlint": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
-            "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
-            "dev": true,
-            "dependencies": {
-                "@secretlint/config-creator": "^10.2.2",
-                "@secretlint/formatter": "^10.2.2",
-                "@secretlint/node": "^10.2.2",
-                "@secretlint/profiler": "^10.2.2",
-                "debug": "^4.4.1",
-                "globby": "^14.1.0",
-                "read-pkg": "^9.0.1"
-            },
-            "bin": {
-                "secretlint": "bin/secretlint.js"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
         },
         "node_modules/semver": {
             "version": "7.7.4",
@@ -6521,35 +5121,6 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/slash": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/slice-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6558,26 +5129,6 @@
             "optional": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/spdx-correct": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-            "dev": true,
-            "dependencies": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
             }
         },
         "node_modules/spdx-exceptions": {
@@ -6612,16 +5163,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/stoppable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4",
-                "npm": ">=6"
             }
         },
         "node_modules/string_decoder": {
@@ -6698,15 +5239,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/structured-source": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
-            "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
-            "dev": true,
-            "dependencies": {
-                "boundary": "^2.0.0"
-            }
-        },
         "node_modules/supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -6727,73 +5259,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/supports-hyperlinks": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0",
-                "supports-color": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
-            }
-        },
-        "node_modules/supports-hyperlinks/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/table": {
-            "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
-            "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-            "dev": true,
-            "dependencies": {
-                "ajv": "^8.0.1",
-                "lodash.truncate": "^4.4.2",
-                "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/table/node_modules/ajv": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/table/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
         },
         "node_modules/tapable": {
             "version": "2.2.1",
@@ -6847,22 +5312,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/terminal-link": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
-            "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-escapes": "^7.0.0",
-                "supports-hyperlinks": "^3.2.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/test-exclude": {
@@ -6974,27 +5423,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
-        "node_modules/textextensions": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
-            "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
-            "dev": true,
-            "dependencies": {
-                "editions": "^6.21.0"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
-            }
-        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7087,12 +5515,6 @@
             "peerDependencies": {
                 "typescript": ">=4.8.4"
             }
-        },
-        "node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
@@ -7190,27 +5612,6 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
         },
-        "node_modules/unicorn-magic": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7232,15 +5633,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
-        "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -7254,38 +5646,6 @@
             },
             "engines": {
                 "node": ">=10.12.0"
-            }
-        },
-        "node_modules/validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "dependencies": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
-        "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/version-range": {
-            "version": "4.15.0",
-            "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
-            "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
             }
         },
         "node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -534,7 +534,7 @@
         "@typescript-eslint/parser": "^8.44.1",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.3.9",
-        "@vscode/vsce": "^3.0.0",
+        "@vscode/vsce": "2.25.0",
         "esbuild": "^0.28.0",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.0.0",


### PR DESCRIPTION
## Description

- Fixes moderate severity vulnerability in uuid package (GHSA-w5hq-g745-h8pq)
- Addresses dependency chain: @vscode/vsce → @azure/identity → @azure/msal-node → uuid
- Downgrades from 3.0.0 to 2.25.0 for security
- Resolves missing buffer bounds check in uuid v3/v5/v6
- Maintains extension packaging functionality

Security: Fixes CVE related to buffer overflow in UUID generation

## Related Issue

https://github.com/bazel-contrib/vscode-bazel/security/dependabot/68

