### PR TITLE
feat(Buildifier): Allow enabling /disabling buildifier functionality 

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
                     "default": true,
                     "markdownDescription": "Whether to show Bazel packages and targets in a tree view in the Explorer panel. Deactivate to avoid running queries in the background."
                 },
+                "bazel.enableBuildifier": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Whether to enable Buildifier support for formatting and linting Bazel files. When enabled, provides document formatting and lint diagnostics for BUILD, WORKSPACE, and .bzl files."
+                },
                 "bazel.pathsToIgnore": {
                     "type": "array",
                     "items": {

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -50,12 +50,13 @@ export async function buildifierFormat(
   fileContent: string,
   filePath: string,
   applyLintFixes: boolean,
+  executable?: string,
 ): Promise<string> {
   const args = [`--mode=fix`, `--path=${filePath}`];
   if (applyLintFixes) {
     args.push(`--lint=fix`);
   }
-  return (await executeBuildifier(fileContent, args, false)).stdout;
+  return (await executeBuildifier(fileContent, args, false, executable)).stdout;
 }
 
 /**
@@ -73,6 +74,7 @@ export async function buildifierLint(
   fileContent: string,
   filePath: string,
   lintMode: "fix",
+  executable?: string,
 ): Promise<string>;
 
 /**
@@ -90,12 +92,14 @@ export async function buildifierLint(
   fileContent: string,
   filePath: string,
   lintMode: "warn",
+  executable?: string,
 ): Promise<IBuildifierWarning[]>;
 
 export async function buildifierLint(
   fileContent: string,
   filePath: string,
   lintMode: BuildifierLintMode,
+  executable?: string,
 ): Promise<string | IBuildifierWarning[]> {
   const args = [
     `--format=json`,
@@ -103,7 +107,7 @@ export async function buildifierLint(
     `--path=${filePath}`,
     `--lint=${lintMode}`,
   ];
-  const outputs = await executeBuildifier(fileContent, args, true);
+  const outputs = await executeBuildifier(fileContent, args, true, executable);
   switch (lintMode) {
     case "fix":
       return outputs.stdout;

--- a/src/buildifier/buildifier_availability.ts
+++ b/src/buildifier/buildifier_availability.ts
@@ -110,7 +110,7 @@ export async function checkBuildifierIsAvailable(): Promise<string | null> {
  * @param reason The reason that Buildifier was not valid, which is displayed
  * to the user.
  */
-async function showBuildifierDownloadPrompt(reason: string) {
+export async function showBuildifierDownloadPrompt(reason: string) {
   const message =
     `${reason}; linting and formatting of Bazel files ` +
     "will not be available. Please download it from " +

--- a/src/buildifier/buildifier_availability.ts
+++ b/src/buildifier/buildifier_availability.ts
@@ -19,7 +19,7 @@ import which from "which";
 
 import { executeBuildifier } from "./buildifier";
 import { getBuildifierExecutablePath } from "../extension/configuration";
-import { logWarn } from "../extension/logger";
+import { logInfo, logWarn } from "../extension/logger";
 
 async function fileExists(filename: string) {
   try {
@@ -52,6 +52,7 @@ const BUILDTOOLS_RELEASES_URL =
  */
 export async function checkBuildifierIsAvailable(): Promise<string | null> {
   const buildifierExecutable = getBuildifierExecutablePath();
+  logInfo(`Checking buildifier availability: ${buildifierExecutable}`);
 
   // Check if the program exists (in case it's an actual executable and not
   // an target name starting with `@`).
@@ -92,9 +93,11 @@ export async function checkBuildifierIsAvailable(): Promise<string | null> {
   );
   try {
     JSON.parse(stdout);
+    logInfo(`Buildifier is available and compatible: ${executablePath}`);
     return executablePath;
   } catch {
     // If we got no valid JSON back, we don't have a compatible version.
+    logWarn("Buildifier version check failed - incompatible version");
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     showBuildifierDownloadPrompt(
       "Buildifier is too old (0.25.1 or higher is needed)",

--- a/src/buildifier/buildifier_availability.ts
+++ b/src/buildifier/buildifier_availability.ts
@@ -83,14 +83,20 @@ export async function checkBuildifierIsAvailable(): Promise<string | null> {
   // Make sure it's a compatible version by running
   // buildifier on an empty input and see if it exits successfully and the
   // output parses.
-  const { stdout } = await executeBuildifier(
-    "",
-    // specify the --lint value even though off is the default in case
-    // a .buildifer.json with a different value is present
-    ["--format=json", "--mode=check", "--lint=off"],
-    false,
-    executablePath,
-  );
+  let stdout: string;
+  try {
+    ({ stdout } = await executeBuildifier(
+      "",
+      // specify the --lint value even though off is the default in case
+      // a .buildifer.json with a different value is present
+      ["--format=json", "--mode=check", "--lint=off"],
+      false,
+      executablePath,
+    ));
+  } catch (e) {
+    logWarn(`Buildifier version check failed: ${e}`);
+    return null;
+  }
   try {
     JSON.parse(stdout);
     logInfo(`Buildifier is available and compatible: ${executablePath}`);

--- a/src/buildifier/buildifier_diagnostics_manager.ts
+++ b/src/buildifier/buildifier_diagnostics_manager.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { buildifierLint } from "./buildifier";
 import { BazelWorkspaceInfo } from "../bazel";
+import { ILogger } from "../extension/logger";
 
 /**
  * The delay to wait for the user to finish typing before invoking buildifier to
@@ -34,12 +35,14 @@ export class BuildifierDiagnosticsManager implements vscode.Disposable {
    * manager itself is disposed.
    */
   private disposables: vscode.Disposable[] = [];
+  private logger: ILogger;
 
   /**
    * Initializes a new buildifier diagnostics manager and hooks into workspace
    * and window events so that diagnostics are updated live.
    */
-  constructor() {
+  constructor(logger: ILogger) {
+    this.logger = logger;
     let didChangeTextTimer: NodeJS.Timeout | null;
 
     this.disposables.push(
@@ -81,10 +84,15 @@ export class BuildifierDiagnosticsManager implements vscode.Disposable {
    */
   public async updateDiagnostics(document: vscode.TextDocument) {
     if (document.languageId === "starlark") {
+      this.logger.logDebug(`Updating diagnostics for ${document.uri.fsPath}`);
+
       const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
       if (!workspaceInfo) {
-        // eslint-disable-next-line no-console
-        console.warn("No workspace info found for document", document.uri);
+        this.logger.logDebug(
+          "No workspace info found for document",
+          false,
+          document.uri.fsPath,
+        );
         return;
       }
       const workspaceRelativePath = path.relative(
@@ -97,6 +105,7 @@ export class BuildifierDiagnosticsManager implements vscode.Disposable {
         workspaceRelativePath,
         "warn",
       );
+      this.logger.logDebug(`Found ${warnings.length} warnings`);
 
       this.diagnosticsCollection.set(
         document.uri,

--- a/src/buildifier/buildifier_diagnostics_manager.ts
+++ b/src/buildifier/buildifier_diagnostics_manager.ts
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
-import * as path from "path";
 import { buildifierLint } from "./buildifier";
-import { BazelWorkspaceInfo } from "../bazel";
 import { ILogger } from "../extension/logger";
 
 /**
@@ -86,23 +84,11 @@ export class BuildifierDiagnosticsManager implements vscode.Disposable {
     if (document.languageId === "starlark") {
       this.logger.logDebug(`Updating diagnostics for ${document.uri.fsPath}`);
 
-      const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
-      if (!workspaceInfo) {
-        this.logger.logDebug(
-          "No workspace info found for document",
-          false,
-          document.uri.fsPath,
-        );
-        return;
-      }
-      const workspaceRelativePath = path.relative(
-        workspaceInfo.bazelWorkspacePath,
-        document.uri.fsPath,
-      );
+      const absolutePath = document.uri.fsPath;
 
       const warnings = await buildifierLint(
         document.getText(),
-        workspaceRelativePath,
+        absolutePath,
         "warn",
       );
       this.logger.logDebug(`Found ${warnings.length} warnings`);

--- a/src/buildifier/buildifier_diagnostics_manager.ts
+++ b/src/buildifier/buildifier_diagnostics_manager.ts
@@ -34,13 +34,15 @@ export class BuildifierDiagnosticsManager implements vscode.Disposable {
    */
   private disposables: vscode.Disposable[] = [];
   private logger: ILogger;
+  private executable: string | undefined;
 
   /**
    * Initializes a new buildifier diagnostics manager and hooks into workspace
    * and window events so that diagnostics are updated live.
    */
-  constructor(logger: ILogger) {
+  constructor(logger: ILogger, executable?: string) {
     this.logger = logger;
+    this.executable = executable;
     let didChangeTextTimer: NodeJS.Timeout | null;
 
     this.disposables.push(
@@ -90,6 +92,7 @@ export class BuildifierDiagnosticsManager implements vscode.Disposable {
         document.getText(),
         absolutePath,
         "warn",
+        this.executable,
       );
       this.logger.logDebug(`Found ${warnings.length} warnings`);
 

--- a/src/buildifier/buildifier_feature.ts
+++ b/src/buildifier/buildifier_feature.ts
@@ -1,0 +1,83 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as vscode from "vscode";
+
+import { BaseExtensionFeature } from "../extension/extension_feature";
+import {
+  checkBuildifierIsAvailable,
+  showBuildifierDownloadPrompt,
+} from "./buildifier_availability";
+import { BuildifierDiagnosticsManager } from "./buildifier_diagnostics_manager";
+import { BuildifierFormatProvider } from "./buildifier_format_provider";
+
+/**
+ * Buildifier feature for Bazel BUILD and Starlark files.
+ * Responsible for:
+ * - Extension activation
+ * - Precondition checks
+ * - Provider registration with VSCode
+ * - Diagnostics management for lint warnings
+ * - Document formatting support
+ */
+export class BuildifierFeature extends BaseExtensionFeature {
+  private diagnosticsManager?: BuildifierDiagnosticsManager;
+
+  constructor(context: vscode.ExtensionContext) {
+    super("Buildifier", context);
+  }
+
+  enable(context: vscode.ExtensionContext): boolean {
+    // Precondition: buildifier executable available
+    if (!checkBuildifierIsAvailable()) {
+      this.logWarn("Can not activate, no buildifier executable found.");
+
+      // Asynchronously show download prompt without waiting for it
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      showBuildifierDownloadPrompt("Buildifier was not found");
+
+      return false;
+    }
+
+    // Create and register the diagnostics manager for lint warnings
+    this.diagnosticsManager = new BuildifierDiagnosticsManager();
+    this.disposables.push(this.diagnosticsManager);
+
+    // Create and register the document formatting provider
+    const formatProvider = new BuildifierFormatProvider();
+    const formatRegistration =
+      vscode.languages.registerDocumentFormattingEditProvider(
+        [
+          { language: "starlark" },
+          { pattern: "**/BUILD" },
+          { pattern: "**/*.bazel" },
+          { pattern: "**/WORKSPACE" },
+          { pattern: "**/*.BUILD" },
+          { pattern: "**/*.bzl" },
+          { pattern: "**/*.sky" },
+        ],
+        formatProvider,
+      );
+    this.disposables.push(formatRegistration);
+
+    return true;
+  }
+
+  /**
+   * Get the diagnostics manager for testing purposes.
+   */
+  getDiagnosticsManager(): BuildifierDiagnosticsManager | undefined {
+    return this.diagnosticsManager;
+  }
+}

--- a/src/buildifier/buildifier_feature.ts
+++ b/src/buildifier/buildifier_feature.ts
@@ -51,11 +51,13 @@ export class BuildifierFeature extends BaseExtensionFeature {
     }
 
     // Create and register the diagnostics manager for lint warnings
-    this.diagnosticsManager = new BuildifierDiagnosticsManager();
+    this.diagnosticsManager = new BuildifierDiagnosticsManager(
+      this.getLogger(),
+    );
     this.disposables.push(this.diagnosticsManager);
 
     // Create and register the document formatting provider
-    const formatProvider = new BuildifierFormatProvider();
+    const formatProvider = new BuildifierFormatProvider(this.getLogger());
     const formatRegistration =
       vscode.languages.registerDocumentFormattingEditProvider(
         [

--- a/src/buildifier/buildifier_feature.ts
+++ b/src/buildifier/buildifier_feature.ts
@@ -46,11 +46,15 @@ export class BuildifierFeature extends BaseExtensionFeature {
     // Create and register the diagnostics manager for lint warnings
     this.diagnosticsManager = new BuildifierDiagnosticsManager(
       this.getLogger(),
+      buildifierPath,
     );
     this.disposables.push(this.diagnosticsManager);
 
     // Create and register the document formatting provider
-    const formatProvider = new BuildifierFormatProvider(this.getLogger());
+    const formatProvider = new BuildifierFormatProvider(
+      this.getLogger(),
+      buildifierPath,
+    );
     const formatRegistration =
       vscode.languages.registerDocumentFormattingEditProvider(
         [

--- a/src/buildifier/buildifier_feature.ts
+++ b/src/buildifier/buildifier_feature.ts
@@ -15,10 +15,7 @@
 import * as vscode from "vscode";
 
 import { BaseExtensionFeature } from "../extension/extension_feature";
-import {
-  checkBuildifierIsAvailable,
-  showBuildifierDownloadPrompt,
-} from "./buildifier_availability";
+import { checkBuildifierIsAvailable } from "./buildifier_availability";
 import { BuildifierDiagnosticsManager } from "./buildifier_diagnostics_manager";
 import { BuildifierFormatProvider } from "./buildifier_format_provider";
 
@@ -38,15 +35,11 @@ export class BuildifierFeature extends BaseExtensionFeature {
     super("Buildifier", context);
   }
 
-  enable(context: vscode.ExtensionContext): boolean {
+  protected async enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Precondition: buildifier executable available
-    if (!checkBuildifierIsAvailable()) {
+    const buildifierPath = await checkBuildifierIsAvailable();
+    if (!buildifierPath) {
       this.logWarn("Can not activate, no buildifier executable found.");
-
-      // Asynchronously show download prompt without waiting for it
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      showBuildifierDownloadPrompt("Buildifier was not found");
-
       return false;
     }
 

--- a/src/buildifier/buildifier_format_provider.ts
+++ b/src/buildifier/buildifier_format_provider.ts
@@ -17,7 +17,7 @@ import * as path from "path";
 import { buildifierFormat } from "./buildifier";
 import { BazelWorkspaceInfo } from "../bazel";
 import { getBuildifierFixOnFormat } from "../extension/configuration";
-import { logError } from "../extension/logger";
+import { ILogger } from "../extension/logger";
 
 /**
  * Provides document formatting functionality for Bazel files by invoking
@@ -26,12 +26,25 @@ import { logError } from "../extension/logger";
 export class BuildifierFormatProvider
   implements vscode.DocumentFormattingEditProvider
 {
+  private logger: ILogger;
+
+  constructor(logger: ILogger) {
+    this.logger = logger;
+  }
+
   public async provideDocumentFormattingEdits(
     document: vscode.TextDocument,
   ): Promise<vscode.TextEdit[]> {
+    this.logger.logDebug(`Formatting document: ${document.uri.fsPath}`);
+
     const fileContent = document.getText();
     const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
     if (!workspaceInfo) {
+      this.logger.logDebug(
+        "No workspace info found for document during formatting",
+        false,
+        document.uri.fsPath,
+      );
       return [];
     }
     const workspaceRelativePath = path.relative(
@@ -45,6 +58,7 @@ export class BuildifierFormatProvider
         getBuildifierFixOnFormat(),
       );
       if (formattedContent === fileContent) {
+        this.logger.logDebug("File did not change during formatting");
         // If the file didn't change, return any empty array of edits.
         return [];
       }
@@ -58,9 +72,10 @@ export class BuildifierFormatProvider
           formattedContent,
         ),
       ];
+      this.logger.logDebug("Returning formatting edits");
       return edits;
     } catch (err: any) {
-      logError("Buildifier formatting failed", true, err);
+      this.logger.logError("Buildifier formatting failed", true, err);
       return [];
     }
   }

--- a/src/buildifier/buildifier_format_provider.ts
+++ b/src/buildifier/buildifier_format_provider.ts
@@ -25,9 +25,11 @@ export class BuildifierFormatProvider
   implements vscode.DocumentFormattingEditProvider
 {
   private logger: ILogger;
+  private executable: string | undefined;
 
-  constructor(logger: ILogger) {
+  constructor(logger: ILogger, executable?: string) {
     this.logger = logger;
+    this.executable = executable;
   }
 
   public async provideDocumentFormattingEdits(
@@ -42,6 +44,7 @@ export class BuildifierFormatProvider
         fileContent,
         absolutePath,
         getBuildifierFixOnFormat(),
+        this.executable,
       );
       if (formattedContent === fileContent) {
         this.logger.logDebug("File did not change during formatting");

--- a/src/buildifier/buildifier_format_provider.ts
+++ b/src/buildifier/buildifier_format_provider.ts
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
-import * as path from "path";
 import { buildifierFormat } from "./buildifier";
-import { BazelWorkspaceInfo } from "../bazel";
 import { getBuildifierFixOnFormat } from "../extension/configuration";
 import { ILogger } from "../extension/logger";
 
@@ -38,23 +36,11 @@ export class BuildifierFormatProvider
     this.logger.logDebug(`Formatting document: ${document.uri.fsPath}`);
 
     const fileContent = document.getText();
-    const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
-    if (!workspaceInfo) {
-      this.logger.logDebug(
-        "No workspace info found for document during formatting",
-        false,
-        document.uri.fsPath,
-      );
-      return [];
-    }
-    const workspaceRelativePath = path.relative(
-      workspaceInfo.bazelWorkspacePath,
-      document.uri.fsPath,
-    );
+    const absolutePath = document.uri.fsPath;
     try {
       const formattedContent = await buildifierFormat(
         fileContent,
-        workspaceRelativePath,
+        absolutePath,
         getBuildifierFixOnFormat(),
       );
       if (formattedContent === fileContent) {

--- a/src/buildifier/index.ts
+++ b/src/buildifier/index.ts
@@ -15,5 +15,6 @@
 export * from "./buildifier";
 export * from "./buildifier_availability";
 export * from "./buildifier_diagnostics_manager";
+export * from "./buildifier_feature";
 export * from "./buildifier_format_provider";
 export * from "./buildifier_result";

--- a/src/codelens/code_lens_feature.ts
+++ b/src/codelens/code_lens_feature.ts
@@ -16,7 +16,7 @@ export class CodeLensFeature extends BaseExtensionFeature {
     super("CodeLens", context);
   }
 
-  enable(context: vscode.ExtensionContext): boolean {
+  async enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");

--- a/src/codelens/code_lens_feature.ts
+++ b/src/codelens/code_lens_feature.ts
@@ -16,11 +16,11 @@ export class CodeLensFeature extends BaseExtensionFeature {
     super("CodeLens", context);
   }
 
-  async enable(context: vscode.ExtensionContext): Promise<boolean> {
+  enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");
-      return false;
+      return Promise.resolve(false);
     }
 
     // Create and register the CodeLens provider
@@ -48,6 +48,6 @@ export class CodeLensFeature extends BaseExtensionFeature {
 
     this.disposables.push(codeLensRegistration, buildWatcher);
 
-    return true;
+    return Promise.resolve(true);
   }
 }

--- a/src/codelens/code_lens_provider.ts
+++ b/src/codelens/code_lens_provider.ts
@@ -77,7 +77,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
     const workspaceInfo = BazelWorkspaceInfo.fromDocument(document);
     if (workspaceInfo === undefined) {
       // Not in a Bazel Workspace.
-      this.logger.logInfo(
+      this.logger.logWarn(
         "Skipping CodeLens - not in Bazel workspace:",
         false,
         document.uri.fsPath,
@@ -99,7 +99,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
     });
 
     if (queryResult === undefined) {
-      this.logger.logInfo(
+      this.logger.logWarn(
         "Skipping CodeLens - query failed for:",
         false,
         document.uri.fsPath,
@@ -108,7 +108,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
     }
 
     const codeLenses = this.builder.buildCodeLenses(workspaceInfo, queryResult);
-    this.logger.logInfo(
+    this.logger.logDebug(
       `Generated ${codeLenses.length} CodeLenses for:`,
       false,
       document.uri.fsPath,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -74,17 +74,17 @@ export async function activate(context: vscode.ExtensionContext) {
   registerBazelWorkspaceAvailabilityWatcher(context);
 
   // WorkspaceTreeFeature
-  const workspaceTreeFeature = WorkspaceTreeFeature.create(context);
+  const workspaceTreeFeature = await WorkspaceTreeFeature.create(context);
   context.subscriptions.push(workspaceTreeFeature);
   storeWorkspaceTreeProviderForTesting(
     workspaceTreeFeature.getWorkspaceTreeProvider(),
   );
 
   // CodeLensFeature
-  context.subscriptions.push(CodeLensFeature.create(context));
+  context.subscriptions.push(await CodeLensFeature.create(context));
 
   // BuildifierFeature
-  context.subscriptions.push(BuildifierFeature.create(context));
+  context.subscriptions.push(await BuildifierFeature.create(context));
 
   // Other components
   let completionItemProvider: BazelCompletionItemProvider | null = null;

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -16,11 +16,7 @@ import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 
 import { activateTaskProvider } from "../bazel";
-import {
-  BuildifierDiagnosticsManager,
-  BuildifierFormatProvider,
-  checkBuildifierIsAvailable,
-} from "../buildifier";
+import { BuildifierFeature } from "../buildifier";
 import { CodeLensFeature } from "../codelens/code_lens_feature";
 import {
   BazelWorkspaceTreeProvider,
@@ -87,8 +83,10 @@ export async function activate(context: vscode.ExtensionContext) {
   // CodeLensFeature
   context.subscriptions.push(CodeLensFeature.create(context));
 
+  // BuildifierFeature
+  context.subscriptions.push(BuildifierFeature.create(context));
+
   // Other components
-  const buildifierDiagnostics = new BuildifierDiagnosticsManager();
   let completionItemProvider: BazelCompletionItemProvider | null = null;
   let lspClient: lc.LanguageClient | undefined;
 
@@ -170,20 +168,6 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       },
     }),
-    // Buildifier formatting support
-    vscode.languages.registerDocumentFormattingEditProvider(
-      [
-        { language: "starlark" },
-        { pattern: "**/BUILD" },
-        { pattern: "**/*.bazel" },
-        { pattern: "**/WORKSPACE" },
-        { pattern: "**/*.BUILD" },
-        { pattern: "**/*.bzl" },
-        { pattern: "**/*.sky" },
-      ],
-      new BuildifierFormatProvider(),
-    ),
-    buildifierDiagnostics,
     // Task provider
     ...activateTaskProvider(),
     // Command variables
@@ -191,16 +175,6 @@ export async function activate(context: vscode.ExtensionContext) {
     // Test provider
     ...activateTesting(),
   );
-
-  // Notify the user if buildifier is not available on their path (or where
-  // their settings expect it).
-  // We intentionally do no `await` the completion because doing so would mean
-  // that VS Code considers the extension activation to be "in-flight" until the
-  // users closes the "Buildifier not found" notification. VS Code hence
-  // dislayed  never-finishing "Loading" indicator on top of the "Bazel Build
-  // Targets" tree view.
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  checkBuildifierIsAvailable();
 }
 
 /** Called when the extension is deactivated. */

--- a/src/extension/extension_feature.ts
+++ b/src/extension/extension_feature.ts
@@ -76,7 +76,7 @@ export abstract class BaseExtensionFeature
     // Register configuration change listener
     this.configCallback = vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration(this.configKey)) {
-        this.onConfigurationChanged(vscode.workspace.getConfiguration());
+        void this.onConfigurationChanged(vscode.workspace.getConfiguration());
       }
     });
   }
@@ -85,13 +85,13 @@ export abstract class BaseExtensionFeature
    * Static Factory pattern for creating and ensuring a subsequent call for initialization.
    * The feature will be initialized based on the current configuration.
    */
-  static create<T extends BaseExtensionFeature>(
+  static async create<T extends BaseExtensionFeature>(
     this: new (context: vscode.ExtensionContext) => T,
     context: vscode.ExtensionContext,
-  ): T {
+  ): Promise<T> {
     const instance = new this(context);
     // Enable/Disable feature based on current configuration
-    instance.onConfigurationChanged(vscode.workspace.getConfiguration());
+    await instance.onConfigurationChanged(vscode.workspace.getConfiguration());
     return instance;
   }
 
@@ -102,11 +102,13 @@ export abstract class BaseExtensionFeature
    * Logs erros in case of a activation failure.
    * @param config The new configuration for the feature.
    */
-  private onConfigurationChanged(config: vscode.WorkspaceConfiguration): void {
+  private async onConfigurationChanged(
+    config: vscode.WorkspaceConfiguration,
+  ): Promise<void> {
     const shouldBeEnabled = this.isEnabledInConfig(config);
     if (shouldBeEnabled && !this.isEnabled) {
       this.logInfo(`Enabling ${this.constructor.name}`);
-      if (!this.enable(this.context)) {
+      if (!(await this.enable(this.context))) {
         void showUserMessage(
           `Failed to enable ${this.constructor.name}`,
           vscode.LogLevel.Error,
@@ -147,7 +149,9 @@ export abstract class BaseExtensionFeature
    * - create any required resources and add disposables to the `this.disposables` array.
    * - return true after successfull enabling of the functionality
    */
-  protected abstract enable(context: vscode.ExtensionContext): boolean;
+  protected abstract enable(
+    context: vscode.ExtensionContext,
+  ): Promise<boolean>;
 
   /**
    * Called when the feature is disabled.

--- a/src/extension/extension_feature.ts
+++ b/src/extension/extension_feature.ts
@@ -41,6 +41,7 @@ export abstract class BaseExtensionFeature
    * Whether the feature is currently enabled.
    */
   private isEnabled: boolean = false;
+  private pendingConfigChange: Promise<void> = Promise.resolve();
 
   /**
    * List of disposables registered by the feature.
@@ -102,13 +103,30 @@ export abstract class BaseExtensionFeature
    * Logs erros in case of a activation failure.
    * @param config The new configuration for the feature.
    */
-  private async onConfigurationChanged(
+  private onConfigurationChanged(
+    config: vscode.WorkspaceConfiguration,
+  ): Promise<void> {
+    const next = this.pendingConfigChange.then(() =>
+      this.doConfigurationChange(config),
+    );
+    this.pendingConfigChange = next.catch(() => {});
+    return next;
+  }
+
+  private async doConfigurationChange(
     config: vscode.WorkspaceConfiguration,
   ): Promise<void> {
     const shouldBeEnabled = this.isEnabledInConfig(config);
     if (shouldBeEnabled && !this.isEnabled) {
       this.logInfo(`Enabling ${this.constructor.name}`);
-      if (!(await this.enable(this.context))) {
+      let enabled: boolean;
+      try {
+        enabled = await this.enable(this.context);
+      } catch (e) {
+        this.logError(`Failed to enable ${this.constructor.name}: ${e}`);
+        return;
+      }
+      if (!enabled) {
         void showUserMessage(
           `Failed to enable ${this.constructor.name}`,
           vscode.LogLevel.Error,

--- a/src/extension/extension_feature.ts
+++ b/src/extension/extension_feature.ts
@@ -109,6 +109,7 @@ export abstract class BaseExtensionFeature
     const next = this.pendingConfigChange.then(() =>
       this.doConfigurationChange(config),
     );
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     this.pendingConfigChange = next.catch(() => {});
     return next;
   }
@@ -167,9 +168,7 @@ export abstract class BaseExtensionFeature
    * - create any required resources and add disposables to the `this.disposables` array.
    * - return true after successfull enabling of the functionality
    */
-  protected abstract enable(
-    context: vscode.ExtensionContext,
-  ): Promise<boolean>;
+  protected abstract enable(context: vscode.ExtensionContext): Promise<boolean>;
 
   /**
    * Called when the feature is disabled.

--- a/src/workspace-tree/workspace_tree_feature.ts
+++ b/src/workspace-tree/workspace_tree_feature.ts
@@ -22,7 +22,7 @@ export class WorkspaceTreeFeature extends BaseExtensionFeature {
     super("WorkspaceTree", context);
   }
 
-  enable(context: vscode.ExtensionContext): boolean {
+  async enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");

--- a/src/workspace-tree/workspace_tree_feature.ts
+++ b/src/workspace-tree/workspace_tree_feature.ts
@@ -22,11 +22,11 @@ export class WorkspaceTreeFeature extends BaseExtensionFeature {
     super("WorkspaceTree", context);
   }
 
-  async enable(context: vscode.ExtensionContext): Promise<boolean> {
+  enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");
-      return false;
+      return Promise.resolve(false);
     }
 
     // Create and register the WorkspaceTree provider
@@ -62,7 +62,7 @@ export class WorkspaceTreeFeature extends BaseExtensionFeature {
     );
     this.disposables.push(refreshTargetsCommand);
 
-    return true;
+    return Promise.resolve(true);
   }
 
   /**

--- a/test/buildifier.test.ts
+++ b/test/buildifier.test.ts
@@ -28,11 +28,19 @@ describe("buildifier", () => {
     "bazel_workspace",
   );
 
+  // Create a mock logger
+  const mockLogger = {
+    logDebug: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+    logInfo: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+    logWarn: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+    logError: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+  };
+
   it("diagnostics are added from buildifier", async () => {
     // Create DiagnosticsManager and open file
     const buildFile = path.join(workspacePath, "buildifier", "BUILD");
     await openSourceFile(buildFile);
-    disposables.push(new BuildifierDiagnosticsManager());
+    disposables.push(new BuildifierDiagnosticsManager(mockLogger));
 
     // Promise that resolves when diagnostics are added to the file.
     const diagnosticsPromise = new Promise<vscode.Diagnostic[]>((resolve) => {

--- a/test/code_lens_feature.test.ts
+++ b/test/code_lens_feature.test.ts
@@ -29,15 +29,15 @@ describe("CodeLensFeature", () => {
   });
 
   describe("enable", () => {
-    it("returns false when Bazel executable is not available", () => {
+    it("returns false when Bazel executable is not available", async () => {
       sandbox.stub(bazel_availability, "checkBazelIsAvailable").returns(false);
 
-      const result = codeLensFeature.enable(mockContext);
+      const result = await codeLensFeature.enable(mockContext);
 
       assert.strictEqual(result, false);
     });
 
-    it("returns true when all preconditions are met", () => {
+    it("returns true when all preconditions are met", async () => {
       const registerStub = sandbox
         .stub(vscode.languages, "registerCodeLensProvider")
         .returns(mockDisposable);
@@ -47,7 +47,7 @@ describe("CodeLensFeature", () => {
           onDidChange: sinon.stub(),
         } as unknown as vscode.FileSystemWatcher);
 
-      const result = codeLensFeature.enable(mockContext);
+      const result = await codeLensFeature.enable(mockContext);
 
       // Assert that feature enables successfully
       assert.strictEqual(result, true);

--- a/test/extension_feature.test.ts
+++ b/test/extension_feature.test.ts
@@ -8,9 +8,7 @@ class TestExtensionFeature extends BaseExtensionFeature {
     super("TestFeature", context);
   }
 
-  protected async enable(
-    context: vscode.ExtensionContext,
-  ): Promise<boolean> {
+  protected async enable(context: vscode.ExtensionContext): Promise<boolean> {
     this.disposables.push({
       dispose: () => {
         /* empty */
@@ -25,9 +23,7 @@ class FailingTestFeature extends BaseExtensionFeature {
     super("FailingTestFeature", context);
   }
 
-  protected async enable(
-    context: vscode.ExtensionContext,
-  ): Promise<boolean> {
+  protected async enable(context: vscode.ExtensionContext): Promise<boolean> {
     return false;
   }
 }

--- a/test/extension_feature.test.ts
+++ b/test/extension_feature.test.ts
@@ -8,7 +8,9 @@ class TestExtensionFeature extends BaseExtensionFeature {
     super("TestFeature", context);
   }
 
-  protected enable(context: vscode.ExtensionContext): boolean {
+  protected async enable(
+    context: vscode.ExtensionContext,
+  ): Promise<boolean> {
     this.disposables.push({
       dispose: () => {
         /* empty */
@@ -23,7 +25,9 @@ class FailingTestFeature extends BaseExtensionFeature {
     super("FailingTestFeature", context);
   }
 
-  protected enable(context: vscode.ExtensionContext): boolean {
+  protected async enable(
+    context: vscode.ExtensionContext,
+  ): Promise<boolean> {
     return false;
   }
 }
@@ -48,7 +52,7 @@ describe("BaseExtensionFeature", () => {
   });
 
   describe("create", () => {
-    it("creates and initializes the feature", () => {
+    it("creates and initializes the feature", async () => {
       const configStub = sandbox
         .stub(vscode.workspace, "getConfiguration")
         .returns({
@@ -56,7 +60,7 @@ describe("BaseExtensionFeature", () => {
         } as any);
       const setContextStub = sandbox.stub(vscode.commands, "executeCommand");
 
-      const feature = TestExtensionFeature.create(mockContext);
+      const feature = await TestExtensionFeature.create(mockContext);
 
       sinon.assert.calledOnce(configStub);
       assert.ok((feature as any).disposables.length > 0);
@@ -70,13 +74,13 @@ describe("BaseExtensionFeature", () => {
   });
 
   describe("onConfigurationChanged", () => {
-    it("enables when config is true and not enabled", () => {
+    it("enables when config is true and not enabled", async () => {
       const config = {
         get: sinon.stub().withArgs("bazel.enableTestFeature").returns(true),
       } as any;
       const setContextStub = sandbox.stub(vscode.commands, "executeCommand");
 
-      (testFeature as any).onConfigurationChanged(config);
+      await (testFeature as any).onConfigurationChanged(config);
 
       assert.strictEqual((testFeature as any).isEnabled, true);
       assert.ok((testFeature as any).disposables.length > 0);
@@ -88,12 +92,12 @@ describe("BaseExtensionFeature", () => {
       );
     });
 
-    it("disables when config is false and enabled", () => {
+    it("disables when config is false and enabled", async () => {
       // First enable
       const configTrue = {
         get: sinon.stub().withArgs("bazel.enableTestFeature").returns(true),
       } as any;
-      (testFeature as any).onConfigurationChanged(configTrue);
+      await (testFeature as any).onConfigurationChanged(configTrue);
       assert.strictEqual((testFeature as any).isEnabled, true);
 
       // Then disable
@@ -101,7 +105,7 @@ describe("BaseExtensionFeature", () => {
         get: sinon.stub().withArgs("bazel.enableTestFeature").returns(false),
       } as any;
       const setContextStub = sandbox.stub(vscode.commands, "executeCommand");
-      (testFeature as any).onConfigurationChanged(configFalse);
+      await (testFeature as any).onConfigurationChanged(configFalse);
 
       assert.strictEqual((testFeature as any).isEnabled, false);
       assert.strictEqual((testFeature as any).disposables.length, 0);
@@ -113,7 +117,7 @@ describe("BaseExtensionFeature", () => {
       );
     });
 
-    it("does not enable if enable returns false", () => {
+    it("does not enable if enable returns false", async () => {
       const config = {
         get: sinon
           .stub()
@@ -124,7 +128,7 @@ describe("BaseExtensionFeature", () => {
         .stub(vscode.window, "showErrorMessage")
         .resolves();
 
-      (failingFeature as any).onConfigurationChanged(config);
+      await (failingFeature as any).onConfigurationChanged(config);
 
       assert.strictEqual((failingFeature as any).isEnabled, false);
       sinon.assert.calledWith(
@@ -135,12 +139,12 @@ describe("BaseExtensionFeature", () => {
   });
 
   describe("disable", () => {
-    it("disposes all disposables", () => {
+    it("disposes all disposables", async () => {
       // Enable first
       const config = {
         get: sinon.stub().withArgs("bazel.enableTestFeature").returns(true),
       } as any;
-      (testFeature as any).onConfigurationChanged(config);
+      await (testFeature as any).onConfigurationChanged(config);
       assert.ok((testFeature as any).disposables.length > 0);
 
       const disposeSpy = sandbox.spy(


### PR DESCRIPTION
## Description

- Add BuildifierFeature class extending BaseExtensionFeature
- Add bazel.enableBuildifier configuration setting (default: true)
- Move buildifier diagnostics and formatting provider registration into feature
- Extract showBuildifierDownloadPrompt for async user notifications
- Remove duplicate buildifier availability checks from extension.ts
- Maintain backward compatibility with existing buildifier functionality
- Make buildifier feature independent of the presence of a bazel workspace (now uses absolute paths)

This change encapsulates buildifier support as a toggleable feature following the same patterns as CodeLensFeature and WorkspaceTreeFeature.

## Related Issue

Related to #490 
Closes #193
Related to #402
Closes #449
Closes #620 

## Testing

- [x] Tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows the project's style guidelines (prettier/eslint)
- [X] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [x] Tests pass locally (`npm run test`)
