### PR TITLE
feat(LanguageSupport): Allow enabling/disabling language support functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,11 @@
                     "default": "...:*",
                     "description": "A [query language expression](https://bazel.build/query/language) which determines the packages and targets displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*` or `kind('.*_test rule', //...)`"
                 },
+                "bazel.enableLanguageSupport": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable language support (Go To Definition, Symbols, Completion) for Bazel files. Automatically uses external LSP if configured, otherwise uses built-in completion, symbols, and go to definition."
+                },
                 "bazel.lsp.command": {
                     "type": "string",
                     "default": "",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
-import * as lc from "vscode-languageclient/node";
 
 import { activateTaskProvider } from "../bazel";
 import {
@@ -26,18 +25,13 @@ import {
   BazelWorkspaceTreeProvider,
   WorkspaceTreeFeature,
 } from "../workspace-tree";
-import { BazelCompletionItemProvider } from "../completion-provider";
-import {
-  BazelGotoDefinitionProvider,
-  targetToUri,
-} from "../definition/bazel_goto_definition_provider";
-import { BazelTargetSymbolProvider } from "../symbols";
+import { targetToUri } from "../definition/bazel_goto_definition_provider";
 import { activateCommandVariables } from "./command_variables";
 import { activateTesting } from "../test-explorer";
 import { activateWrapperCommands } from "./bazel_wrapper_commands";
 import { registerLogger, logInfo, logError, showOutputChannel } from "./logger";
-import { startLspClientFromCurrentConfig } from "../lsp/language-server-client";
 import { registerBazelWorkspaceAvailabilityWatcher } from "../bazel/bazel_availability";
+import { LanguageSupportFeature } from "../language_support/language_support_feature";
 
 // Global reference to the workspace tree provider for testing
 declare global {
@@ -89,60 +83,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Other components
   const buildifierDiagnostics = new BuildifierDiagnosticsManager();
-  let completionItemProvider: BazelCompletionItemProvider | null = null;
-  let lspClient: lc.LanguageClient | undefined;
 
-  // Set up LSP if enabled
-  const config = vscode.workspace.getConfiguration("bazel");
-  const lspEnabled = !!config.get<string>("lsp.command");
-  if (lspEnabled) {
-    context.subscriptions.push(
-      vscode.commands.registerCommand("bazel.lsp.restart", async () => {
-        await startLspClientFromCurrentConfig(lspClient, context);
-      }),
-    );
-    await startLspClientFromCurrentConfig(lspClient, context);
-  } else {
-    completionItemProvider = new BazelCompletionItemProvider();
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    completionItemProvider.refresh();
-
-    // Set up file watcher for BUILD files
-    const buildWatcher = vscode.workspace.createFileSystemWatcher(
-      "**/{BUILD,BUILD.bazel}",
-      false, // ignoreCreateEvents
-      false, // ignoreChangeEvents
-      false, // ignoreDeleteEvents
-    );
-
-    // Fire refresh when BUILD files change
-    buildWatcher.onDidChange(
-      () => completionItemProvider?.refresh(),
-      null,
-      context.subscriptions,
-    );
-
-    context.subscriptions.push(
-      vscode.languages.registerCompletionItemProvider(
-        [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
-        completionItemProvider,
-        "/",
-        ":",
-      ),
-      // Symbol provider for BUILD files
-      vscode.languages.registerDocumentSymbolProvider(
-        [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
-        new BazelTargetSymbolProvider(),
-      ),
-      // Goto definition for BUILD files
-      vscode.languages.registerDefinitionProvider(
-        [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
-        new BazelGotoDefinitionProvider(),
-      ),
-    );
-  }
-
-  vscode.commands.executeCommand("setContext", "bazel.lsp.enabled", lspEnabled);
+  // Initialize language support feature
+  context.subscriptions.push(LanguageSupportFeature.create(context));
 
   context.subscriptions.push(
     // Commands

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -80,7 +80,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(await BuildifierFeature.create(context));
 
   // LanguageSupportFeature
-  context.subscriptions.push(LanguageSupportFeature.create(context));
+  context.subscriptions.push(await LanguageSupportFeature.create(context));
 
   context.subscriptions.push(
     // Commands

--- a/src/language_support/language-server-client.ts
+++ b/src/language_support/language-server-client.ts
@@ -21,6 +21,16 @@ import {
   getLspServerExecutablePath,
 } from "../extension/configuration";
 
+// Singleton output channel for LSP to prevent duplication
+let lspOutputChannel: vscode.OutputChannel | undefined;
+
+function getLspOutputChannel(): vscode.OutputChannel {
+  if (!lspOutputChannel) {
+    lspOutputChannel = vscode.window.createOutputChannel("Bazel LSP Client");
+  }
+  return lspOutputChannel;
+}
+
 export async function startLspClientFromCurrentConfig(
   lspClient: lc.LanguageClient | undefined,
   context: vscode.ExtensionContext,
@@ -67,12 +77,15 @@ async function _createLspClient(): Promise<lc.LanguageClient> {
 
   const clientOptions: lc.LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "starlark" }],
+    outputChannel: getLspOutputChannel(), // Set shared output channel
   };
 
-  return new lc.LanguageClient(
+  const client = new lc.LanguageClient(
     "bazel",
     "Bazel LSP Client",
     serverOptions,
     clientOptions,
   );
+
+  return client;
 }

--- a/src/language_support/language-server-client.ts
+++ b/src/language_support/language-server-client.ts
@@ -22,11 +22,13 @@ import {
 } from "../extension/configuration";
 
 // Singleton output channel for LSP to prevent duplication
-let lspOutputChannel: vscode.OutputChannel | undefined;
+let lspOutputChannel: vscode.LogOutputChannel | undefined;
 
-function getLspOutputChannel(): vscode.OutputChannel {
+function getLspOutputChannel(): vscode.LogOutputChannel {
   if (!lspOutputChannel) {
-    lspOutputChannel = vscode.window.createOutputChannel("Bazel LSP Client");
+    lspOutputChannel = vscode.window.createOutputChannel("Bazel LSP Client", {
+      log: true,
+    });
   }
   return lspOutputChannel;
 }

--- a/src/language_support/language_support_feature.ts
+++ b/src/language_support/language_support_feature.ts
@@ -1,0 +1,155 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as vscode from "vscode";
+import * as lc from "vscode-languageclient/node";
+
+import { BaseExtensionFeature } from "../extension/extension_feature";
+import { BazelCompletionItemProvider } from "../completion-provider";
+import { BazelGotoDefinitionProvider } from "../definition/bazel_goto_definition_provider";
+import { BazelTargetSymbolProvider } from "../symbols";
+import { startLspClientFromCurrentConfig } from "./language-server-client";
+import { getLspServerExecutablePath } from "../extension/configuration";
+
+/**
+ * Language Support feature for Bazel.
+ * Handles both external LSP and built-in language support implementations.
+ * Automatically chooses implementation based on LSP configuration.
+ */
+export class LanguageSupportFeature extends BaseExtensionFeature {
+  private lspClient: lc.LanguageClient | undefined;
+  private completionItemProvider: BazelCompletionItemProvider | null = null;
+  private isUsingExternalLSP: boolean = false;
+
+  constructor(context: vscode.ExtensionContext) {
+    super("LanguageSupport", context);
+  }
+
+  enable(context: vscode.ExtensionContext): boolean {
+    // Determine which implementation to use
+    const lspCommand = getLspServerExecutablePath();
+    this.isUsingExternalLSP = !!lspCommand;
+
+    if (this.isUsingExternalLSP) {
+      return this.enableExternalLSP(context);
+    } else {
+      return this.enableBuiltInSupport(context);
+    }
+  }
+
+  protected disable(): boolean {
+    // Clean up both implementations to be safe
+    if (this.lspClient) {
+      this.lspClient.stop().catch((error) => {
+        this.logError("Error stopping language server", true, error);
+      });
+      this.lspClient = undefined;
+    }
+
+    this.completionItemProvider = null;
+
+    // Clear context key for use in package.json
+    vscode.commands.executeCommand("setContext", "bazel.lsp.enabled", false);
+
+    return super.disable();
+  }
+
+  /**
+   * Enables external LSP implementation
+   */
+  private enableExternalLSP(context: vscode.ExtensionContext): boolean {
+    this.logInfo("Enabling external language server support");
+
+    // Register restart command
+    const restartCommand = vscode.commands.registerCommand(
+      "bazel.lsp.restart",
+      async () => {
+        this.logInfo("Restarting language server...");
+        await startLspClientFromCurrentConfig(this.lspClient, context);
+      },
+    );
+    this.disposables.push(restartCommand);
+
+    // Start the LSP client
+    startLspClientFromCurrentConfig(this.lspClient, context)
+      .then(() => {
+        this.logInfo("External language server started successfully");
+      })
+      .catch((error: any) => {
+        this.logError("Failed to start external language server", true, error);
+        return false;
+      });
+
+    // Set context key for use in package.json
+    vscode.commands.executeCommand("setContext", "bazel.lsp.enabled", true);
+
+    return true;
+  }
+
+  /**
+   * Enables built-in language support implementation
+   */
+  private enableBuiltInSupport(context: vscode.ExtensionContext): boolean {
+    this.logInfo("Enabling built-in language support");
+
+    // Create completion provider
+    this.completionItemProvider = new BazelCompletionItemProvider();
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.completionItemProvider.refresh();
+
+    // Set up file watcher for BUILD files
+    const buildWatcher = vscode.workspace.createFileSystemWatcher(
+      "**/{BUILD,BUILD.bazel}",
+      false, // ignoreCreateEvents
+      false, // ignoreChangeEvents
+      false, // ignoreDeleteEvents
+    );
+
+    // Fire refresh when BUILD files change
+    const buildWatcherDisposable = buildWatcher.onDidChange(() =>
+      this.completionItemProvider?.refresh(),
+    );
+
+    // Register language providers
+    const completionRegistration =
+      vscode.languages.registerCompletionItemProvider(
+        [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
+        this.completionItemProvider,
+        "/",
+        ":",
+      );
+
+    const symbolRegistration = vscode.languages.registerDocumentSymbolProvider(
+      [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
+      new BazelTargetSymbolProvider(),
+    );
+
+    const definitionRegistration = vscode.languages.registerDefinitionProvider(
+      [{ pattern: "**/BUILD" }, { pattern: "**/BUILD.bazel" }],
+      new BazelGotoDefinitionProvider(),
+    );
+
+    // Add all disposables
+    this.disposables.push(
+      buildWatcher,
+      buildWatcherDisposable,
+      completionRegistration,
+      symbolRegistration,
+      definitionRegistration,
+    );
+
+    this.logInfo("Built-in language support enabled successfully");
+    return true;
+  }
+}

--- a/src/language_support/language_support_feature.ts
+++ b/src/language_support/language_support_feature.ts
@@ -36,7 +36,7 @@ export class LanguageSupportFeature extends BaseExtensionFeature {
     super("LanguageSupport", context);
   }
 
-  enable(context: vscode.ExtensionContext): boolean {
+  protected async enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Determine which implementation to use
     const lspCommand = getLspServerExecutablePath();
     this.isUsingExternalLSP = !!lspCommand;


### PR DESCRIPTION
## Description

- Create single LanguageSupportFeature that handles both external LSP and built-in implementations
- Automatically choose implementation based on bazel.lsp.command configuration (as it was)
- Refactor LSP client management to prevent duplicate output channels (when re-enabling)
- Ensure proper resource cleanup and disposable management
- Rename lsp folder to language_support

## Related Issue

Related to #490

## Testing

<!-- Describe how you tested your changes -->

- [ ] Tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows the project's style guidelines (prettier/eslint)
- [x] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [x] Tests pass locally (`npm run test`)
