### PR TITLE
chore: enable no-misused-promises eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,7 @@ module.exports = [
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/no-misused-promises": "error",
       "@typescript-eslint/no-namespace": "error",
       "@typescript-eslint/no-parameter-properties": "off",
       "@typescript-eslint/no-shadow": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1541,6 +1541,7 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -1651,6 +1652,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
             "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.2",
                 "@typescript-eslint/types": "8.57.2",
@@ -2317,6 +2319,7 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3488,6 +3491,7 @@
             "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -4973,6 +4977,7 @@
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
             "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -5888,6 +5893,7 @@
             "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@types/node": ">=13.7.0",
                 "long": "^5.0.0"
@@ -7007,6 +7013,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7128,6 +7135,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
             "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1541,7 +1541,6 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -1652,7 +1651,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
             "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.2",
                 "@typescript-eslint/types": "8.57.2",
@@ -2319,7 +2317,6 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3491,7 +3488,6 @@
             "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -4977,7 +4973,6 @@
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
             "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -5893,7 +5888,6 @@
             "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@types/node": ">=13.7.0",
                 "long": "^5.0.0"
@@ -7013,7 +7007,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7135,7 +7128,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
             "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/src/debug-adapter/client.ts
+++ b/src/debug-adapter/client.ts
@@ -154,7 +154,7 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  protected async configurationDoneRequest(
+  async _configurationDoneRequest(
     response: DebugProtocol.ConfigurationDoneResponse,
   ) {
     await this.bazelConnection.sendRequest({
@@ -164,7 +164,13 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  protected async launchRequest(
+  protected configurationDoneRequest(
+    response: DebugProtocol.ConfigurationDoneResponse,
+  ) {
+    void this._configurationDoneRequest(response);
+  }
+
+  async _launchRequest(
     response: DebugProtocol.LaunchResponse,
     args: ILaunchRequestArguments,
   ) {
@@ -199,6 +205,13 @@ class BazelDebugSession extends DebugSession {
     this.bazelConnection.on("event", (event) => {
       this.handleBazelEvent(event as skylark_debugging.DebugEvent);
     });
+  }
+
+  protected launchRequest(
+    response: DebugProtocol.LaunchResponse,
+    args: ILaunchRequestArguments,
+  ) {
+    void this._launchRequest(response, args);
   }
 
   protected disconnectRequest(response: DebugProtocol.DisconnectResponse) {
@@ -281,7 +294,7 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  protected async stackTraceRequest(
+  async _stackTraceRequest(
     response: DebugProtocol.StackTraceResponse,
     args: DebugProtocol.StackTraceArguments,
   ) {
@@ -320,6 +333,13 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
+  protected stackTraceRequest(
+    response: DebugProtocol.StackTraceResponse,
+    args: DebugProtocol.StackTraceArguments,
+  ) {
+    void this._stackTraceRequest(response, args);
+  }
+
   protected scopesRequest(
     response: DebugProtocol.ScopesResponse,
     args: DebugProtocol.ScopesArguments,
@@ -342,7 +362,7 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  protected async variablesRequest(
+  async _variablesRequest(
     response: DebugProtocol.VariablesResponse,
     args: DebugProtocol.VariablesArguments,
   ) {
@@ -398,7 +418,14 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  protected async evaluateRequest(
+  protected variablesRequest(
+    response: DebugProtocol.VariablesResponse,
+    args: DebugProtocol.VariablesArguments,
+  ) {
+    void this._variablesRequest(response, args);
+  }
+
+  async _evaluateRequest(
     response: DebugProtocol.EvaluateResponse,
     args: DebugProtocol.EvaluateArguments,
   ) {
@@ -432,6 +459,13 @@ class BazelDebugSession extends DebugSession {
     } catch (e) {
       this.debugLog(`Unable to evaluate expression: ${args.expression}`);
     }
+  }
+
+  protected evaluateRequest(
+    response: DebugProtocol.EvaluateResponse,
+    args: DebugProtocol.EvaluateArguments,
+  ) {
+    void this._evaluateRequest(response, args);
   }
 
   // Execution/control flow requests

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -249,10 +249,9 @@ describe("The logger", () => {
       logError("test error", true);
       // The mock function should be called synchronously when showUserMessage
       // calls messageFunc. However, since showUserMessage returns a promise
-      // that's called with void, we need to wait for the microtask queue.
-      await new Promise((resolve) =>
-        Promise.resolve().then(() => resolve(undefined)),
-      );
+      // that's called with void, we need to wait for the microtask queue (twice).
+      await Promise.resolve();
+      await Promise.resolve();
       assert.strictEqual(
         messageCalls.length,
         1,
@@ -278,9 +277,8 @@ describe("The logger", () => {
     it("shows warning message when showMessage is true", async () => {
       disposable = registerLogger(mockContext);
       logWarn("test warning", true);
-      await new Promise((resolve) =>
-        Promise.resolve().then(() => resolve(undefined)),
-      );
+      await Promise.resolve();
+      await Promise.resolve();
       assert.strictEqual(
         messageCalls.length,
         1,
@@ -306,9 +304,8 @@ describe("The logger", () => {
     it("shows info message when showMessage is true", async () => {
       disposable = registerLogger(mockContext);
       logInfo("test info", true);
-      await new Promise((resolve) =>
-        Promise.resolve().then(() => resolve(undefined)),
-      );
+      await Promise.resolve();
+      await Promise.resolve();
       assert.strictEqual(
         messageCalls.length,
         1,
@@ -466,9 +463,8 @@ describe("The logger", () => {
     it("shows message and formats additional arguments correctly", async () => {
       disposable = registerLogger(mockContext);
       logError("error occurred", true, "Error code:", 500);
-      await new Promise((resolve) =>
-        Promise.resolve().then(() => resolve(undefined)),
-      );
+      await Promise.resolve();
+      await Promise.resolve();
       const calls = (mockLogChannel as any)._calls;
       const errorCall = calls.find(
         (c: { method: string }) => c.method === "error",
@@ -501,9 +497,8 @@ describe("The logger", () => {
     it("shows warning message with multiple additional arguments", async () => {
       disposable = registerLogger(mockContext);
       logWarn("warning", true, "arg1", "arg2", 123);
-      await new Promise((resolve) =>
-        Promise.resolve().then(() => resolve(undefined)),
-      );
+      await Promise.resolve();
+      await Promise.resolve();
       const calls = (mockLogChannel as any)._calls;
       const warnCall = calls.find(
         (c: { method: string }) => c.method === "warn",
@@ -541,9 +536,8 @@ describe("The logger", () => {
       disposable = registerLogger(mockContext);
       const data = { userId: 123, action: "login" };
       logInfo("operation completed", true, "Data:", data);
-      await new Promise((resolve) =>
-        Promise.resolve().then(() => resolve(undefined)),
-      );
+      await Promise.resolve();
+      await Promise.resolve();
       const calls = (mockLogChannel as any)._calls;
       const infoCalls = calls.filter(
         (c: { method: string }) => c.method === "info",


### PR DESCRIPTION
This rule would have caught an issue with #629 if it were enabled, particularly the `checksConditionals` part. A few modifications had to be made to accommodate the `checksVoidReturn` part of the rule.