### PR TITLE
build: Activate more eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,7 +40,7 @@ module.exports = [
       jsdoc,
     },
     rules: {
-      // TypeScript rules
+      "@typescript-eslint/prefer-optional-chain": "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,7 @@ module.exports = [
     },
     rules: {
       "@typescript-eslint/prefer-optional-chain": "error",
+      "@typescript-eslint/return-await": ["error", "in-try-catch"],
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,6 +45,13 @@ module.exports = [
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/promise-function-async": "error",
       "@typescript-eslint/prefer-includes": "error",
+      "@typescript-eslint/explicit-member-accessibility": [
+        "error",
+        {
+          accessibility: "explicit",
+          overrides: { constructors: "no-public" },
+        },
+      ],
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,7 @@ module.exports = [
       "@typescript-eslint/return-await": ["error", "in-try-catch"],
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/promise-function-async": "error",
+      "@typescript-eslint/prefer-includes": "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,9 @@ module.exports = [
       "@typescript-eslint/no-duplicate-enum-values": "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/prefer-reduce-type-parameter": "error",
+      "jsdoc/require-throws": "warn",
+      "jsdoc/require-yields": "warn",
+      "jsdoc/no-undefined-types": "error",
       "@typescript-eslint/array-type": [
         "error",
         {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,8 @@ module.exports = [
           overrides: { constructors: "no-public" },
         },
       ],
+      "@typescript-eslint/no-unnecessary-parameter-property-assignment":
+        "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,7 @@ module.exports = [
       ],
       "@typescript-eslint/no-unnecessary-parameter-property-assignment":
         "error",
+      "@typescript-eslint/no-duplicate-enum-values": "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,7 @@ module.exports = [
         "error",
       "@typescript-eslint/no-duplicate-enum-values": "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
+      "@typescript-eslint/prefer-reduce-type-parameter": "error",
       "@typescript-eslint/array-type": [
         "error",
         {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,7 @@ module.exports = [
     rules: {
       "@typescript-eslint/prefer-optional-chain": "error",
       "@typescript-eslint/return-await": ["error", "in-try-catch"],
+      "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,6 +60,19 @@ module.exports = [
       "jsdoc/require-throws": "warn",
       "jsdoc/require-yields": "warn",
       "jsdoc/no-undefined-types": "error",
+      // Rules that require activation of strictNullChecks in tsconfig.json first
+      // "@typescript-eslint/strict-boolean-expressions": ["error", {
+      //   "allowString": false,
+      //   "allowNumber": false,
+      //   "allowNullableObject": false,
+      //   "allowNullableBoolean": false,
+      //   "allowNullableString": false,
+      //   "allowNullableNumber": false,
+      //   "allowAny": false,
+      // }],
+      // "@typescript-eslint/prefer-nullish-coalescing": "error",
+      // "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+
       "@typescript-eslint/array-type": [
         "error",
         {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,7 @@ module.exports = [
       "@typescript-eslint/prefer-optional-chain": "error",
       "@typescript-eslint/return-await": ["error", "in-try-catch"],
       "@typescript-eslint/await-thenable": "error",
+      "@typescript-eslint/promise-function-async": "error",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -5,6 +5,7 @@ let assertionFailureReported = false;
 
 /**
  * Asserts that the given value is true.
+ * @throws {Error} If the value is not true.
  */
 export function assert(value: boolean): asserts value {
   if (!value) {

--- a/src/bazel/bazel_command.ts
+++ b/src/bazel/bazel_command.ts
@@ -54,10 +54,10 @@ export abstract class BazelCommand {
    * @param options Command line options that will be passed to Bazel (targets,
    * query strings, flags, etc.).
    */
-  public constructor(
-    readonly bazelExecutable: string,
-    readonly workingDirectory: string,
-    readonly options: string[] = [],
+  constructor(
+    protected readonly bazelExecutable: string,
+    protected readonly workingDirectory: string,
+    protected readonly options: string[] = [],
   ) {}
 
   /**

--- a/src/bazel/bazel_query.ts
+++ b/src/bazel/bazel_query.ts
@@ -46,7 +46,7 @@ export class BazelQuery extends BazelCommand {
    * be sorted by their name.
    * @param options.ignoresErrors `true` if errors from executing the query
    * should be ignored.
-   * @returns A {@link QueryResult} object that contains structured information
+   * @returns A {@link blaze_query.QueryResult} object that contains structured information
    * about the query results.
    */
   public async queryTargets(

--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -75,15 +75,15 @@ export class BazelTargetQuickPick
     return this.targetInfo;
   }
 
-  get alwaysShow(): boolean {
+  public get alwaysShow(): boolean {
     return true;
   }
 
-  get label(): string {
+  public get label(): string {
     return this.targetLabel;
   }
 
-  get picked(): boolean {
+  public get picked(): boolean {
     return false;
   }
 

--- a/src/bazel/bazel_quickpick.ts
+++ b/src/bazel/bazel_quickpick.ts
@@ -253,7 +253,7 @@ export async function queryQuickPickPackage({
  * @param options.workspaceInfo Workspace information for the Bazel project
  * @returns A promise that resolves with the selected BazelTargetQuickPick, or undefined if no selection was made
  */
-export function showDynamicQuickPick({
+export async function showDynamicQuickPick({
   queryBuilder,
   queryFunctor,
   workspaceInfo,

--- a/src/bazel/query_location.ts
+++ b/src/bazel/query_location.ts
@@ -54,7 +54,7 @@ export class QueryLocation {
    * This property handles the conversation from Bazel's 1-based line/column
    * indices to the 0-based indices that VS Code expects.
    */
-  get range(): vscode.Range {
+  public get range(): vscode.Range {
     return new vscode.Range(
       this.line - 1,
       this.column - 1,

--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -64,11 +64,13 @@ function quotedOption(option: string): vscode.ShellQuotedString {
  * Task provider for `bazel` tasks.
  */
 class BazelTaskProvider implements vscode.TaskProvider {
-  provideTasks(): vscode.ProviderResult<vscode.Task[]> {
+  public provideTasks(): vscode.ProviderResult<vscode.Task[]> {
     // We don't auto-detect any tasks
     return [];
   }
-  async resolveTask(task: vscode.Task): Promise<vscode.Task | undefined> {
+  public async resolveTask(
+    task: vscode.Task,
+  ): Promise<vscode.Task | undefined> {
     // VSCode calls this
     //  * when rerunning a task from the task history in "Run Task"
     //  * for bazel tasks in the user's tasks.json,

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -136,8 +136,7 @@ export async function executeBuildifier(
   executable?: string,
 ): Promise<{ stdout: string; stderr: string }> {
   // Determine the executable
-  let buildifierExecutable =
-    executable || (await getBuildifierExecutablePath());
+  let buildifierExecutable = executable || getBuildifierExecutablePath();
   const buildifierConfigJsonPath = getBuildifierJsonConfigPath();
   if (buildifierConfigJsonPath.length !== 0) {
     args = ["--config", buildifierConfigJsonPath, ...args];

--- a/src/buildifier/buildifier_availability.ts
+++ b/src/buildifier/buildifier_availability.ts
@@ -125,7 +125,7 @@ async function showBuildifierDownloadPrompt(reason: string) {
     title: "Download",
   });
 
-  if (item && item.title === "Download") {
+  if (item?.title === "Download") {
     await vscode.commands.executeCommand(
       "vscode.open",
       vscode.Uri.parse(BUILDTOOLS_RELEASES_URL),

--- a/src/buildifier/buildifier_feature.ts
+++ b/src/buildifier/buildifier_feature.ts
@@ -76,7 +76,7 @@ export class BuildifierFeature extends BaseExtensionFeature {
   /**
    * Get the diagnostics manager for testing purposes.
    */
-  getDiagnosticsManager(): BuildifierDiagnosticsManager | undefined {
+  public getDiagnosticsManager(): BuildifierDiagnosticsManager | undefined {
     return this.diagnosticsManager;
   }
 }

--- a/src/codelens/code_lens_builder.ts
+++ b/src/codelens/code_lens_builder.ts
@@ -46,7 +46,7 @@ export class CodeLensBuilder {
    * @param queryResult The result of the bazel query containing target definitions
    * @returns A new array of CodeLens objects for the BUILD file
    */
-  buildCodeLenses(
+  public buildCodeLenses(
     bazelWorkspaceInfo: BazelWorkspaceInfo,
     queryResult: blaze_query.QueryResult,
   ): vscode.CodeLens[] {

--- a/src/codelens/code_lens_command_adapter.ts
+++ b/src/codelens/code_lens_command_adapter.ts
@@ -34,7 +34,7 @@ export class CodeLensCommandAdapter implements IBazelCommandAdapter {
    * @param workspaceFolder Workspace folder from which to execute Bazel.
    * @param options Other command line arguments to pass to Bazel.
    */
-  public constructor(
+  constructor(
     workspaceInfo: BazelWorkspaceInfo,
     targets: string[],
     options: string[] = [],

--- a/src/codelens/code_lens_feature.ts
+++ b/src/codelens/code_lens_feature.ts
@@ -16,7 +16,7 @@ export class CodeLensFeature extends BaseExtensionFeature {
     super("CodeLens", context);
   }
 
-  enable(context: vscode.ExtensionContext): boolean {
+  protected enable(context: vscode.ExtensionContext): boolean {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");

--- a/src/codelens/code_lens_feature.ts
+++ b/src/codelens/code_lens_feature.ts
@@ -16,7 +16,7 @@ export class CodeLensFeature extends BaseExtensionFeature {
     super("CodeLens", context);
   }
 
-  protected enable(context: vscode.ExtensionContext): Promise<boolean> {
+  protected async enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");

--- a/src/debug-adapter/client.ts
+++ b/src/debug-adapter/client.ts
@@ -136,7 +136,7 @@ class BazelDebugSession extends DebugSession {
   private valueThreadIds = new Map<number, number>();
 
   /** Initializes a new Bazel debug session. */
-  public constructor() {
+  constructor() {
     super();
 
     // Starlark uses 1-based line and column numbers.
@@ -154,7 +154,7 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  async _configurationDoneRequest(
+  private async _configurationDoneRequest(
     response: DebugProtocol.ConfigurationDoneResponse,
   ) {
     await this.bazelConnection.sendRequest({
@@ -170,7 +170,7 @@ class BazelDebugSession extends DebugSession {
     void this._configurationDoneRequest(response);
   }
 
-  async _launchRequest(
+  private async _launchRequest(
     response: DebugProtocol.LaunchResponse,
     args: ILaunchRequestArguments,
   ) {
@@ -294,7 +294,7 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  async _stackTraceRequest(
+  private async _stackTraceRequest(
     response: DebugProtocol.StackTraceResponse,
     args: DebugProtocol.StackTraceArguments,
   ) {
@@ -362,7 +362,7 @@ class BazelDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  async _variablesRequest(
+  private async _variablesRequest(
     response: DebugProtocol.VariablesResponse,
     args: DebugProtocol.VariablesArguments,
   ) {
@@ -425,7 +425,7 @@ class BazelDebugSession extends DebugSession {
     void this._variablesRequest(response, args);
   }
 
-  async _evaluateRequest(
+  private async _evaluateRequest(
     response: DebugProtocol.EvaluateResponse,
     args: DebugProtocol.EvaluateArguments,
   ) {

--- a/src/debug-adapter/connection.ts
+++ b/src/debug-adapter/connection.ts
@@ -66,7 +66,7 @@ export class BazelDebugConnection extends EventEmitter {
    * @param host The host name to connect to.
    * @param port The port number to connect to.
    */
-  public constructor(
+  constructor(
     host: string,
     port: number,
     private logger: (message: string, ...objects: object[]) => void,

--- a/src/debug-adapter/connection.ts
+++ b/src/debug-adapter/connection.ts
@@ -84,7 +84,7 @@ export class BazelDebugConnection extends EventEmitter {
    * populated by this method.
    * @returns A {@code Promise} for the response to the request.
    */
-  public sendRequest(
+  public async sendRequest(
     options: skylark_debugging.IDebugRequest,
   ): Promise<skylark_debugging.IDebugEvent> {
     if (!this.socket) {

--- a/src/extension/command_variables.ts
+++ b/src/extension/command_variables.ts
@@ -98,7 +98,7 @@ async function bazelGetTargetOutput(
     case 1:
       return path.join(outputPath, "..", outputs[0]);
     default:
-      return await vscode.window.showQuickPick(outputs, {
+      return vscode.window.showQuickPick(outputs, {
         placeHolder: `Pick an output of ${target}`,
       });
   }

--- a/src/extension/command_variables.ts
+++ b/src/extension/command_variables.ts
@@ -209,7 +209,7 @@ export function activateCommandVariables(): vscode.Disposable[] {
       const commandName = `bazel.${key}`;
       const funcs = [queryQuickPickPackage, queryQuickPickTargets];
       const func = funcs[idx];
-      return vscode.commands.registerCommand(commandName, (args) =>
+      return vscode.commands.registerCommand(commandName, async (args) =>
         wrapQuickPick(commandName, func, args),
       );
     }),
@@ -222,7 +222,7 @@ export function activateCommandVariables(): vscode.Disposable[] {
       "output_path",
       "workspace",
     ].map((key) =>
-      vscode.commands.registerCommand(`bazel.info.${key}`, () =>
+      vscode.commands.registerCommand(`bazel.info.${key}`, async () =>
         bazelInfo(key),
       ),
     ),

--- a/src/extension/command_variables.ts
+++ b/src/extension/command_variables.ts
@@ -132,6 +132,7 @@ async function bazelInfo(key: string): Promise<string> {
  * @param argName the argument name
  * @param commandName the commmand name. Used in the error message
  * @returns the extracted string value
+ * @throws {Error} If the argument is not a string or is not present.
  */
 function getArgumentValue(
   args: Record<string, any>,

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -32,7 +32,7 @@ export function getConfigurationWithDefault<T>(
   if (!value) {
     const info = config.inspect<T>(name);
 
-    if (!info || info.defaultValue == null) {
+    if (info?.defaultValue == null) {
       throw new Error(`No default value for configuration ${section}.${name}`);
     }
 

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -20,6 +20,7 @@ import * as vscode from "vscode";
  * @param section The section that contains the configuration, as is passed to vscode.workspace.getConfiguration.
  * @param name The name of the configuration item within the section.
  * @returns The configuration value, or its default.
+ * @throws {Error} If the configuration value is not set and has no default.
  */
 export function getConfigurationWithDefault<T>(
   section: string,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -117,7 +117,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Fire refresh when BUILD files change
     buildWatcher.onDidChange(
-      () => completionItemProvider?.refresh(),
+      async () => completionItemProvider?.refresh(),
       null,
       context.subscriptions,
     );

--- a/src/extension/extension_feature.ts
+++ b/src/extension/extension_feature.ts
@@ -33,7 +33,7 @@ export abstract class BaseExtensionFeature
   /**
    * Name of the feature, used in settings.
    */
-  readonly featureName: string;
+  protected readonly featureName: string;
   private readonly configKey: string;
   private readonly contextKey: string;
 
@@ -85,7 +85,7 @@ export abstract class BaseExtensionFeature
    * Static Factory pattern for creating and ensuring a subsequent call for initialization.
    * The feature will be initialized based on the current configuration.
    */
-  static create<T extends BaseExtensionFeature>(
+  public static create<T extends BaseExtensionFeature>(
     this: new (context: vscode.ExtensionContext) => T,
     context: vscode.ExtensionContext,
   ): T {
@@ -203,7 +203,7 @@ export abstract class BaseExtensionFeature
    * Called when the extension is deactivated.
    * Cleanup and dispose all registered disposables, instance is unusable after.
    */
-  dispose() {
+  public dispose() {
     this.disable();
     this.configCallback.dispose();
   }

--- a/src/extension/extension_feature.ts
+++ b/src/extension/extension_feature.ts
@@ -103,10 +103,10 @@ export abstract class BaseExtensionFeature
    * Logs erros in case of a activation failure.
    * @param config The new configuration for the feature.
    */
-  private onConfigurationChanged(
+  private async onConfigurationChanged(
     config: vscode.WorkspaceConfiguration,
   ): Promise<void> {
-    const next = this.pendingConfigChange.then(() =>
+    const next = this.pendingConfigChange.then(async () =>
       this.doConfigurationChange(config),
     );
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/extension/logger.ts
+++ b/src/extension/logger.ts
@@ -249,7 +249,7 @@ function getMessageFunctionForLevel(
 const activeMessages = new Map<string, Promise<string | undefined>>();
 
 /**
- * Shows an user message with an "Details" button that opens the output channel.
+ * Shows an user message with a "Details" button that opens the output channel.
  * Prevents duplicate messages from being shown simultaneously.
  * Returns a promise that resolves to the action selected by the user, or undefined if dismissed.
  *
@@ -258,7 +258,7 @@ const activeMessages = new Map<string, Promise<string | undefined>>();
  * @param showDetailsButton Whether to show the "Details" button.
  * @returns A promise that resolves to the selected action or undefined.
  */
-export function showUserMessage(
+export async function showUserMessage(
   message: string,
   level: vscode.LogLevel,
   showDetailsButton: boolean = true,

--- a/src/language_support/language_support_feature.ts
+++ b/src/language_support/language_support_feature.ts
@@ -117,7 +117,7 @@ export class LanguageSupportFeature extends BaseExtensionFeature {
     );
 
     // Fire refresh when BUILD files change
-    const buildWatcherDisposable = buildWatcher.onDidChange(() =>
+    const buildWatcherDisposable = buildWatcher.onDidChange(async () =>
       this.completionItemProvider?.refresh(),
     );
 

--- a/src/test-explorer/index.ts
+++ b/src/test-explorer/index.ts
@@ -22,7 +22,7 @@ export function activateTesting(): vscode.Disposable[] {
   );
   coverageRunProfile.isDefault = false;
   // `loadDetailedCoverage` is important so that line coverage data is shown.
-  coverageRunProfile.loadDetailedCoverage = (_, coverage) =>
+  coverageRunProfile.loadDetailedCoverage = async (_, coverage) =>
     Promise.resolve((coverage as BazelFileCoverage).details);
 
   return subscriptions;

--- a/src/test-explorer/lcov_parser.ts
+++ b/src/test-explorer/lcov_parser.ts
@@ -165,10 +165,10 @@ async function resolveSourceFilePath(
  */
 export class BazelFileCoverage extends vscode.FileCoverage {
   // The coverage details
-  details: vscode.FileCoverageDetail[] = [];
+  public details: vscode.FileCoverageDetail[] = [];
 
   // Construct the coverage info from the detailed coverage information
-  static fromDetails(
+  public static fromDetails(
     uri: vscode.Uri,
     details: vscode.FileCoverageDetail[],
   ): BazelFileCoverage {
@@ -206,10 +206,12 @@ export async function parseLcov(
   // Note that line numbers in LCOV files seem to be 1-based, while line
   // numbers for VS Code need to be 0-based.
   class FileCoverageInfo {
-    functionsByLine: Map<number, vscode.DeclarationCoverage> = new Map();
-    lineCoverage: Map<number, vscode.StatementCoverage> = new Map();
-    coverageByLineAndBranch: Map<number, Map<string, vscode.BranchCoverage>> =
-      new Map();
+    public functionsByLine: Map<number, vscode.DeclarationCoverage> = new Map();
+    public lineCoverage: Map<number, vscode.StatementCoverage> = new Map();
+    public coverageByLineAndBranch: Map<
+      number,
+      Map<string, vscode.BranchCoverage>
+    > = new Map();
   }
   const infosByFile: Map<string, FileCoverageInfo> = new Map();
   for (const block of lcov.split(/end_of_record(\n|$)/)) {

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -49,7 +49,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     return true;
   }
 
-  public getChildren(): Promise<IBazelTreeItem[]> {
+  public async getChildren(): Promise<IBazelTreeItem[]> {
     return this.getDirectoryItems();
   }
 

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -197,7 +197,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     // have a VS Code workspace that is pointed at a subpackage of a large
     // workspace without the performance penalty of querying the entire
     // workspace.
-    if (!this.workspaceInfo || !this.workspaceInfo.workspaceFolder) {
+    if (!this.workspaceInfo?.workspaceFolder) {
       return Promise.resolve([]);
     }
     const bazelWorkspacePath = this.workspaceInfo.bazelWorkspacePath;

--- a/src/workspace-tree/workspace_tree_feature.ts
+++ b/src/workspace-tree/workspace_tree_feature.ts
@@ -22,7 +22,7 @@ export class WorkspaceTreeFeature extends BaseExtensionFeature {
     super("WorkspaceTree", context);
   }
 
-  enable(context: vscode.ExtensionContext): boolean {
+  protected enable(context: vscode.ExtensionContext): boolean {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");
@@ -68,7 +68,7 @@ export class WorkspaceTreeFeature extends BaseExtensionFeature {
   /**
    * Get the workspace tree provider for testing purposes.
    */
-  getWorkspaceTreeProvider(): BazelWorkspaceTreeProvider | undefined {
+  public getWorkspaceTreeProvider(): BazelWorkspaceTreeProvider | undefined {
     return this.workspaceTreeProvider;
   }
 }

--- a/src/workspace-tree/workspace_tree_feature.ts
+++ b/src/workspace-tree/workspace_tree_feature.ts
@@ -22,7 +22,7 @@ export class WorkspaceTreeFeature extends BaseExtensionFeature {
     super("WorkspaceTree", context);
   }
 
-  protected enable(context: vscode.ExtensionContext): Promise<boolean> {
+  protected async enable(context: vscode.ExtensionContext): Promise<boolean> {
     // Precondition: bazel executable available
     if (!checkBazelIsAvailable()) {
       this.logWarn("Can not activate, no bazel executable found.");

--- a/src/workspace-tree/workspace_tree_provider.ts
+++ b/src/workspace-tree/workspace_tree_provider.ts
@@ -75,10 +75,12 @@ export class BazelWorkspaceTreeProvider
       buildFilesWatcher.onDidCreate(() => this.queueRefresh()),
       buildFilesWatcher.onDidDelete(() => this.queueRefresh()),
       vscode.workspace.onDidChangeWorkspaceFolders(() => this.refresh()),
-      vscode.window.onDidChangeActiveTextEditor(() =>
+      vscode.window.onDidChangeActiveTextEditor(async () =>
         this.syncSelectedTreeItem(),
       ),
-      vscode.workspace.onDidOpenTextDocument(() => this.syncSelectedTreeItem()),
+      vscode.workspace.onDidOpenTextDocument(async () =>
+        this.syncSelectedTreeItem(),
+      ),
     );
 
     this.updateWorkspaceFolderTreeItems();

--- a/test/code_lens_feature.test.ts
+++ b/test/code_lens_feature.test.ts
@@ -32,7 +32,7 @@ describe("CodeLensFeature", () => {
     it("returns false when Bazel executable is not available", () => {
       sandbox.stub(bazel_availability, "checkBazelIsAvailable").returns(false);
 
-      const result = codeLensFeature.enable(mockContext);
+      const result = (codeLensFeature as any).enable(mockContext);
 
       assert.strictEqual(result, false);
     });
@@ -47,7 +47,7 @@ describe("CodeLensFeature", () => {
           onDidChange: sinon.stub(),
         } as unknown as vscode.FileSystemWatcher);
 
-      const result = codeLensFeature.enable(mockContext);
+      const result = (codeLensFeature as any).enable(mockContext);
 
       // Assert that feature enables successfully
       assert.strictEqual(result, true);

--- a/test/lcov_parser.test.ts
+++ b/test/lcov_parser.test.ts
@@ -6,7 +6,7 @@ import { DeclarationCoverage, StatementCoverage } from "vscode";
 
 const testDir = path.join(__dirname, "../..", "test");
 
-function parseTestLcov(lcov: string): Promise<BazelFileCoverage[]> {
+async function parseTestLcov(lcov: string): Promise<BazelFileCoverage[]> {
   return parseLcov("/base", lcov);
 }
 

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -81,7 +81,7 @@ describe("The logger", () => {
     originalShowWarningMessage = vscode.window.showWarningMessage;
     originalShowInfoMessage = vscode.window.showInformationMessage;
 
-    (vscode.window.showErrorMessage as any) = (
+    (vscode.window.showErrorMessage as any) = async (
       message: string,
       ...items: string[]
     ) => {
@@ -91,7 +91,7 @@ describe("The logger", () => {
       return Promise.resolve(undefined);
     };
 
-    (vscode.window.showWarningMessage as any) = (
+    (vscode.window.showWarningMessage as any) = async (
       message: string,
       ...items: string[]
     ) => {
@@ -101,7 +101,7 @@ describe("The logger", () => {
       return Promise.resolve(undefined);
     };
 
-    (vscode.window.showInformationMessage as any) = (
+    (vscode.window.showInformationMessage as any) = async (
       message: string,
       ...items: string[]
     ) => {


### PR DESCRIPTION
## Description

In reaction to #639 and hopefully along the lines of #623, this PR activates some copilot-recommended eslint rules that could help me to better handle typescript and async code in the next PRs.

I have placed each rule activation and necessary fixes into it's own commit to ease reviewing **and/or** dropping individual rules based on reviews - I assume some rules could spark discussions.

Finally, I also added a block of rules that all require `strictNullCheck` to be activated first - and I totally see why we should do that.

## Related Issue

-

## Testing

- [ ] Tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Code follows the project's style guidelines (prettier/eslint)
- [x] Commit messages follow [Conventional Commit](https://www.conventionalcommits.org/) conventions
- [ ] Tests pass locally (`npm run test`)
