### PR TITLE
security: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,10 +21,10 @@ jobs:
     if: ${{ github.repository == 'bazel-contrib/vscode-bazel' }} # Allow CI-runs only for events from/to this repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           cache: "npm"
 
@@ -45,7 +45,7 @@ jobs:
       - name: Lint
         run: npm run lint-check
 
-      - uses: bazel-contrib/setup-bazel@0.19.0
+      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
         with:
           bazelisk-cache: true
           disk-cache: false
@@ -67,13 +67,13 @@ jobs:
         run: npm run package
 
       - name: Upload Workflow Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vscode-bazel-prerelease.vsix
           path: vscode-bazel-*.vsix
           if-no-files-found: error
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,11 @@
     "group:test",
     "group:unitTest",
     "security:minimumReleaseAgeNpm"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
## Description

Tags are mutable — a compromised action maintainer account can silently
move a tag (e.g. v4) to a malicious commit, causing every workflow that
references that tag to execute attacker-controlled code with full runner
permissions. Commit SHAs are immutable, so pinning to them ensures the
exact audited code is always used.

Renovate is configured with pinDigests for the github-actions manager so
it will keep the SHAs up to date whenever a new released version tag is
published.

Link to the respective release pages:
- https://github.com/actions/checkout/releases#release-v6.1.0
- https://github.com/actions/setup-node/releases#release-v6.5.0
- https://github.com/bazel-contrib/setup-bazel/releases#release-0.19.0
- https://github.com/actions/upload-artifact/releases#release-v7.0.1
- https://github.com/googleapis/release-please-action/releases#release-v4.4.1

## Related Issue

[Trivy Under Attack Again: Widespread GitHub Actions Tag Compromise](https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise)
[GitHub Actions Supply Chain Attack Puts Thousands of Projects at Risk](https://socket.dev/blog/github-actions-supply-chain-attack-puts-thousands-of-projects-at-risk)

